### PR TITLE
Fixed NULL error in entity_ident gate.

### DIFF
--- a/lua/wire/gates/duface.lua
+++ b/lua/wire/gates/duface.lua
@@ -117,8 +117,7 @@ GateActions["entity_ident"] = {
 	end,
 	label = function (Out, A)
 		local strEnt = "(none)"
-		if (IsEntity (Out)) then strEnt = Out:GetName () end
-		return string.format ("%s = %s", A, strEnt)
+		return string.format ("%s = %s", A, tostring(Out))
 	end
 }
 // Parent

--- a/lua/wire/gates/duface.lua
+++ b/lua/wire/gates/duface.lua
@@ -116,7 +116,6 @@ GateActions["entity_ident"] = {
 		return nil
 	end,
 	label = function (Out, A)
-		local strEnt = "(none)"
 		return string.format ("%s = %s", A, tostring(Out))
 	end
 }


### PR DESCRIPTION
Fixed an error when no entity was given and as a bonus, it is now conforming with the [wiremod/wire] (https://github.com/wiremod/wire) label format.