### PR TITLE
HS HoloEmitter: Make points show when outside of FOV

### DIFF
--- a/lua/entities/gmod_wire_hsholoemitter/cl_init.lua
+++ b/lua/entities/gmod_wire_hsholoemitter/cl_init.lua
@@ -10,6 +10,7 @@ function ENT:Initialize( )
 	for i = 0, 2047 do
 		self.Memory[i] = 0
 	end
+	self.RBound = Vector(1024,1024,1024)
 end
 
 function HSHoloemitter_DataMsg( um )
@@ -33,6 +34,9 @@ end
 
 function ENT:Think( )
 	self:ShowOutput()
+	-- To make it visible across the entire map
+	local p = LocalPlayer():GetPos()
+	self:SetRenderBoundsWS( p - self.RBound, p + self.RBound )
 end
 
 function ENT:ShowOutput()

--- a/lua/entities/gmod_wire_hsholoemitter/init.lua
+++ b/lua/entities/gmod_wire_hsholoemitter/init.lua
@@ -156,6 +156,10 @@ function ENT:Think()
 	self.lastThinkChange = false
 end
 
+function ENT:UpdateTransmitState()
+    return TRANSMIT_ALWAYS
+end
+
 function HSHoloInteract(ply,cmd,args)
 	local entid = tonumber(args[1])
 	local num = tonumber(args[2])

--- a/lua/entities/gmod_wire_hsholoemitter/init.lua
+++ b/lua/entities/gmod_wire_hsholoemitter/init.lua
@@ -38,12 +38,14 @@ function ENT:Setup()
 	self.packetLen = 0
 	self.lastThinkChange = false
 	
-	//Memory:
-	//0 - Active
-	//2 - point size
-	//3 - show beam
-	//4 - number of points
-	//5... - points list
+	-- Memory:
+	-- 0 - Active
+	-- 1 - readonly: point that is interacted with
+	-- 2 - point size
+	-- 3 - bitmask: 1: show beam 2: global positions 4: individual colors for points
+	-- 4 - number of points
+	-- 5... - points list, format: X,Y,Z, X,Y,Z
+	--	or X,Y,Z,R,G,B,A, X,Y,Z,R,G,B,A with individual color bit set
 	
 	for i = 0, 2047 do
 		self.Memory[i] = 0

--- a/lua/entities/gmod_wire_useholoemitter/cl_init.lua
+++ b/lua/entities/gmod_wire_useholoemitter/cl_init.lua
@@ -14,7 +14,7 @@ function ENT:Initialize( )
 	self.ActivePoint = Vector( 0, 0, 0 );
 	
 	// boundry.
-	self.Boundry = 64;
+	self.RBound = Vector(1024,1024,1024)
 end
 
 // calculate point
@@ -37,6 +37,10 @@ function ENT:Think( )
 		self.PointList = {}
 		self.LastClear = lastclear
 	end
+	
+	-- To make it visible across the entire map
+	local p = LocalPlayer():GetPos()
+	self:SetRenderBoundsWS( p - self.RBound, p + self.RBound )
 	
 	// did the point differ from active point?
 	if( point != self.ActivePoint && self:GetNetworkedBool( "Active" ) ) then
@@ -91,7 +95,6 @@ function ENT:Draw( )
 	// read color
 	local color = self:GetColor();
 	
-	self:SetRenderBounds( Vector()*-16384, Vector()*16384 )	
 	// calculate pixel point.
 	local pixelpos
 	if (usegps == true) then

--- a/lua/entities/gmod_wire_useholoemitter/init.lua
+++ b/lua/entities/gmod_wire_useholoemitter/init.lua
@@ -141,6 +141,10 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	end
 end
 
+function ENT:UpdateTransmitState()
+    return TRANSMIT_ALWAYS
+end
+
 function HoloInteract(ply,cmd,args)
 	local entid = tonumber(args[1])
 	local x = tonumber(args[2])


### PR DESCRIPTION
Same for the Interactable holoemitter, now acts just like the normal wire holo emitter does.
Tested in singleplayer, works as expected (altough interactable HE is not spawnable, but that bug is there regardless of my changes).
Thanks to @bigdogmat for helping me figure out how it works.

Also update the comments:
As there isn't really documentation for the HS Holo Emitter since the wiki/forum are shut down, at least the comments in the source code should not leave out relevant info.  
Did i miss some more undocumented features of the HS Holoemitter?