### PR TITLE
Fixed Wire Magnet Prop Filter

### DIFF
--- a/lua/weapons/gmod_tool/stools/wire_magnet.lua
+++ b/lua/weapons/gmod_tool/stools/wire_magnet.lua
@@ -46,7 +46,7 @@ function TOOL:LeftClick( trace )
 	
 	local leng 		= tonumber(self:GetClientNumber( "leng" ))
 	local strength	 	= tonumber(self:GetClientNumber("streng" ))
-	local propfilter	 	= string.lower( self:GetClientInfo( "propfilter" ) ) --Fixed. local propfilter = tostring(self.ClientConVar[ "propfilter" ]) Does not work.
+	local propfilter	 	= string.lower( self:GetClientInfo( "propfilter" ) )
 	local targetmetal	 	= tonumber(self:GetClientNumber( "targetOnlyMetal" ))==1
 	local starton	 	= tonumber(self:GetClientNumber( "startOn" ))==1
 	

--- a/lua/weapons/gmod_tool/stools/wire_magnet.lua
+++ b/lua/weapons/gmod_tool/stools/wire_magnet.lua
@@ -46,7 +46,7 @@ function TOOL:LeftClick( trace )
 	
 	local leng 		= tonumber(self:GetClientNumber( "leng" ))
 	local strength	 	= tonumber(self:GetClientNumber("streng" ))
-	local propfilter	 	= self:GetClientInfo( "propfilter" ) --Fixed. local propfilter = tostring(self.ClientConVar[ "propfilter" ]) Does not work.
+	local propfilter	 	= string.lower( self:GetClientInfo( "propfilter" ) ) --Fixed. local propfilter = tostring(self.ClientConVar[ "propfilter" ]) Does not work.
 	local targetmetal	 	= tonumber(self:GetClientNumber( "targetOnlyMetal" ))==1
 	local starton	 	= tonumber(self:GetClientNumber( "startOn" ))==1
 	

--- a/lua/weapons/gmod_tool/stools/wire_magnet.lua
+++ b/lua/weapons/gmod_tool/stools/wire_magnet.lua
@@ -46,7 +46,7 @@ function TOOL:LeftClick( trace )
 	
 	local leng 		= tonumber(self:GetClientNumber( "leng" ))
 	local strength	 	= tonumber(self:GetClientNumber("streng" ))
-	local propfilter	 	= tostring(self.ClientConVar[ "propfilter" ])
+	local propfilter	 	= self:GetClientInfo( "propfilter" ) --Fixed. local propfilter = tostring(self.ClientConVar[ "propfilter" ]) Does not work.
 	local targetmetal	 	= tonumber(self:GetClientNumber( "targetOnlyMetal" ))==1
 	local starton	 	= tonumber(self:GetClientNumber( "startOn" ))==1
 	


### PR DESCRIPTION
Wire magnet had problems when you wanted it to attract a specific model. There was a simple mistake in its code. I changed it.
"local propfilter = string.lower( self:GetClientInfo( "propfilter" ) )" Instead "local propfilter = tostring(self.ClientConVar[ "propfilter" ])". It simply returned no value.