### PR TITLE
Fixed: Issue #72 - The script will not crash when the player is not s…

### DIFF
--- a/lua/weapons/gmod_tool/stools/wire_dupeport.lua
+++ b/lua/weapons/gmod_tool/stools/wire_dupeport.lua
@@ -10,12 +10,52 @@ if ( CLIENT ) then
 	language.Add( "Tool.wire_dupeport.name", "Adv. Dupe. Teleporter Tool (Wire)" )
 	language.Add( "Tool.wire_dupeport.desc", "Spawns an Adv. Dupe. Teleporter for use with the wire system." )
 	language.Add( "Tool.wire_dupeport.0", "Primary: Create/Update Adv. Dupe. Teleporter" )
-	language.Add( "sboxlimit_wire_dupeports", "You've hit Adv. Dupe. Teleporters limit!" )
-	language.Add( "undone_wiredupeport", "Undone Wire Adv. Dupe. Teleporter" )
+	language.Add( "Cleanup_wire_dupeports", "Wire Adv. Dupe. Teleporters" )
+	language.Add( "Cleaned_wire_dupeports", "Cleaned up Wire Adv. Dupe. Teleporters" )
+	language.Add( "SBoxLimit_wire_dupeports", "You've hit Adv. Dupe. Teleporters limit!" )
+	language.Add( "Undone_wire_dupeport", "Undone Wire Adv. Dupe. Teleporter" )
 end
 
 if ( SERVER ) then
+
 	CreateConVar( "sbox_maxwire_dupeports", 10 )
+
+	function MakeWireDupePort( ply, Ang, Pos)
+		if ( ply:IsAdmin() || ply:IsSuperAdmin() ) then
+
+			if ( !ply:CheckLimit( "wire_dupeports" ) ) then return false end
+
+			local wire_dupeport = ents.Create( "gmod_wire_dupeport" )
+			if ( !wire_dupeport:IsValid() ) then return false end
+
+			wire_dupeport:SetModel( Model( gsModel ) )
+			wire_dupeport:SetBeamLength( 100 )
+			wire_dupeport:SetAngles( Ang )
+			wire_dupeport:SetPos( Pos )
+			wire_dupeport:SetOverlayText( "Adv. Dupe.Teleporter" )
+			wire_dupeport:Spawn()
+
+			wire_dupeport:SetPlayer(ply)
+
+			if ( game.SinglePlayer() ) then
+				wire_dupeport.OwnerSteamID = ply
+				wire_dupeport.SpawnSteamID = ply
+			else
+				wire_dupeport.OwnerSteamID = ply:SteamID()
+				wire_dupeport.SpawnSteamID = ply:SteamID()
+			end
+
+			ply:AddCount( "wire_dupeports", wire_dupeport )
+
+			return wire_dupeport
+		else
+			ply:SendLua( "GAMEMODE:AddNotify(\"A non-admin cannot spawn a Adv. Dupe Teleporter!\", NOTIFY_GENERIC, 5); surface.PlaySound(\"ambient/water/drip"..math.random(1, 4)..".wav\")" )
+			return nil
+		end
+	end
+
+	duplicator.RegisterEntityClass( "gmod_wire_dupeport", MakeWireDupePort, "Ang", "Pos" )
+
 end
 
 cleanup.Register( "wire_dupeports" )
@@ -59,46 +99,6 @@ function TOOL:LeftClick( trace )
 	return true
 end
 
-if ( SERVER ) then
-
-	function MakeWireDupePort( ply, Ang, Pos)
-		if ( ply:IsAdmin() || ply:IsSuperAdmin() ) then
-
-			if ( !ply:CheckLimit( "wire_dupeports" ) ) then return false end
-
-			local wire_dupeport = ents.Create( "gmod_wire_dupeport" )
-			if ( !wire_dupeport:IsValid() ) then return false end
-
-			wire_dupeport:SetModel( Model( gsModel ) )
-			wire_dupeport:SetBeamLength( 100 )
-			wire_dupeport:SetAngles( Ang )
-			wire_dupeport:SetPos( Pos )
-			wire_dupeport:SetOverlayText( "Adv. Dupe.Teleporter" )
-			wire_dupeport:Spawn()
-
-			wire_dupeport:SetPlayer(ply)
-
-			if ( game.SinglePlayer() ) then
-				wire_dupeport.OwnerSteamID = ply
-				wire_dupeport.SpawnSteamID = ply
-			else
-				wire_dupeport.OwnerSteamID = ply:SteamID()
-				wire_dupeport.SpawnSteamID = ply:SteamID()
-			end
-
-			ply:AddCount( "wire_dupeports", wire_dupeport )
-
-			return wire_dupeport
-		else
-			ply:SendLua( "GAMEMODE:AddNotify(\"A non-admin cannot spawn a Adv. Dupe Teleporter!\", NOTIFY_GENERIC, 5); surface.PlaySound(\"ambient/water/drip"..math.random(1, 4)..".wav\")" )
-			return nil
-		end
-	end
-
-	duplicator.RegisterEntityClass( "gmod_wire_dupeport", MakeWireDupePort, "Ang", "Pos" )
-
-end
-
 function TOOL:UpdateGhostWireDupePort( ent, player )
 	if ( !ent ) then return end
 	if ( !ent:IsValid() ) then return end
@@ -136,5 +136,8 @@ function TOOL:Think()
 end
 
 function TOOL.BuildCPanel(panel)
-	panel:AddControl("Header", { Text = "#Tool.wire_dupeport.name", Description = "#Tool.wire_dupeport.desc" })
+	panel:AddControl("Header", {
+		Text        = "#Tool.wire_dupeport.name",
+		Description = "#Tool.wire_dupeport.desc"
+	})
 end

--- a/lua/weapons/gmod_tool/stools/wire_dupeport.lua
+++ b/lua/weapons/gmod_tool/stools/wire_dupeport.lua
@@ -13,7 +13,7 @@ if ( CLIENT ) then
 end
 
 if (SERVER) then
-	CreateConVar('sbox_maxwire_dupeports', 10)
+	CreateConVar("sbox_maxwire_dupeports", 10)
 end
 
 cleanup.Register( "wire_dupeports" )

--- a/lua/weapons/gmod_tool/stools/wire_dupeport.lua
+++ b/lua/weapons/gmod_tool/stools/wire_dupeport.lua
@@ -104,7 +104,8 @@ function TOOL:UpdateGhostWireDupePort( ent, player )
 	local trace = player:GetEyeTrace()
 	if ( not trace.Hit ) then return end
 
-	if (trace.Entity and trace.Entity:GetClass() == "gmod_wire_dupeport" or trace.Entity:IsPlayer() ) then
+	if (trace.Entity and trace.Entity:IsValid() and
+		 (trace.Entity:GetClass() == "gmod_wire_dupeport" or trace.Entity:IsPlayer()) ) then
 		ent:SetNoDraw( true )
 		return
 	end
@@ -122,9 +123,9 @@ end
 
 function TOOL:Think()
 	if ( not self.GhostEntity or
-	     not self.GhostEntity:IsValid() or
-	         self.GhostEntity:GetModel() ~= gsModel ) then
-	  self:MakeGhostEntity( gsModel, Vector(0,0,0), Angle(0,0,0) )
+			 not self.GhostEntity:IsValid() or
+					 self.GhostEntity:GetModel() ~= gsModel ) then
+		self:MakeGhostEntity( gsModel, Vector(0,0,0), Angle(0,0,0) )
 	end
 
 	self:UpdateGhostWireDupePort( self.GhostEntity, self:GetOwner() )

--- a/lua/weapons/gmod_tool/stools/wire_dupeport.lua
+++ b/lua/weapons/gmod_tool/stools/wire_dupeport.lua
@@ -1,8 +1,10 @@
-TOOL.Category		= "Wire Extras/Physics"
-TOOL.Name				= "Adv. Dupe. Teleporter"
-TOOL.Command		= nil
-TOOL.ConfigName	= ""
-TOOL.Tab				= "Wire"
+TOOL.Category   = "Wire Extras/Physics"
+TOOL.Name       = "Adv. Dupe. Teleporter"
+TOOL.Command    = nil
+TOOL.ConfigName = ""
+TOOL.Tab        = "Wire"
+
+local gsModel = "models/jaanus/wiretool/wiretool_speed.mdl"
 
 if ( CLIENT ) then
 	language.Add( "Tool.wire_dupeport.name", "Adv. Dupe. Teleporter Tool (Wire)" )
@@ -12,32 +14,32 @@ if ( CLIENT ) then
 	language.Add( "undone_wiredupeport", "Undone Wire Adv. Dupe. Teleporter" )
 end
 
-if (SERVER) then
+if ( SERVER ) then
 	CreateConVar("sbox_maxwire_dupeports", 10)
 end
 
 cleanup.Register( "wire_dupeports" )
 
 function TOOL:LeftClick( trace )
-	if trace.Entity && trace.Entity:IsPlayer() then return false end
-	if (CLIENT) then return true end
+	if trace.Entity and trace.Entity:IsPlayer() then return false end
+	if ( CLIENT ) then return true end
 
 	local ply = self:GetOwner()
 
 	-- If we shot a wire_dupeport do nothing
-	if ( trace.Entity:IsValid() && trace.Entity:GetClass() == "gmod_wire_dupeport" && trace.Entity.pl == ply ) then
+	if ( trace.Entity:IsValid() and trace.Entity:GetClass() == "gmod_wire_dupeport" and trace.Entity.pl == ply ) then
 		trace.Entity:Setup()
 		return true
 	end
 
-	if ( !self:GetSWEP():CheckLimit( "wire_dupeports" ) ) then return false end
+	if ( not self:GetSWEP():CheckLimit( "wire_dupeports" ) ) then return false end
 
 	local Ang = trace.HitNormal:Angle()
 	Ang.pitch = Ang.pitch + 90
 
 	local wire_dupeport = MakeWireDupePort( ply, Ang, trace.HitPos )
-	if(not wire_dupeport) then return false end
-	if(not wire_dupeport:IsValid()) then return false end
+	if ( not wire_dupeport ) then return false end
+	if ( not wire_dupeport:IsValid() ) then return false end
 
 	local min = wire_dupeport:OBBMins()
 	wire_dupeport:SetPos( trace.HitPos - trace.HitNormal * min.z )
@@ -55,18 +57,18 @@ function TOOL:LeftClick( trace )
 	return true
 end
 
-if (SERVER) then
+if ( SERVER ) then
 
 	function MakeWireDupePort( ply, Ang, Pos)
-		if ply:IsAdmin() or ply:IsSuperAdmin() then
+		if ( ply:IsAdmin() or ply:IsSuperAdmin() ) then
 
-			if ( !ply:CheckLimit( "wire_dupeports" ) ) then return false end
+			if ( not ply:CheckLimit( "wire_dupeports" ) ) then return false end
 
 			local wire_dupeport = ents.Create( "gmod_wire_dupeport" )
-			if (!wire_dupeport:IsValid()) then return false end
+			if ( not wire_dupeport:IsValid() ) then return false end
 
-			wire_dupeport:SetModel( Model("models/jaanus/wiretool/wiretool_speed.mdl") )
-			wire_dupeport:SetBeamLength(100)
+			wire_dupeport:SetModel( Model( gsModel ) )
+			wire_dupeport:SetBeamLength( 100 )
 			wire_dupeport:SetAngles( Ang )
 			wire_dupeport:SetPos( Pos )
 			wire_dupeport:SetOverlayText("Adv. Dupe.Teleporter")
@@ -74,7 +76,7 @@ if (SERVER) then
 
 			wire_dupeport:SetPlayer(ply)
 
-			if (game.SinglePlayer()) then
+			if ( game.SinglePlayer() ) then
 				wire_dupeport.OwnerSteamID = ply
 				wire_dupeport.SpawnSteamID = ply
 			else
@@ -96,13 +98,13 @@ if (SERVER) then
 end
 
 function TOOL:UpdateGhostWireDupePort( ent, player )
-	if ( !ent ) then return end
-	if ( !ent:IsValid() ) then return end
+	if ( not ent ) then return end
+	if ( not ent:IsValid() ) then return end
 
 	local trace = player:GetEyeTrace()
-	if (!trace.Hit) then return end
+	if ( not trace.Hit ) then return end
 
-	if (trace.Entity && trace.Entity:GetClass() == "gmod_wire_dupeport" || trace.Entity:IsPlayer()) then
+	if (trace.Entity and trace.Entity:GetClass() == "gmod_wire_dupeport" or trace.Entity:IsPlayer() ) then
 		ent:SetNoDraw( true )
 		return
 	end
@@ -119,8 +121,10 @@ end
 
 
 function TOOL:Think()
-	if (!self.GhostEntity || !self.GhostEntity:IsValid() || self.GhostEntity:GetModel() != "models/jaanus/wiretool/wiretool_speed.mdl" ) then
-		self:MakeGhostEntity( "models/jaanus/wiretool/wiretool_speed.mdl", Vector(0,0,0), Angle(0,0,0) )
+	if ( not self.GhostEntity or
+	     not self.GhostEntity:IsValid() or
+	         self.GhostEntity:GetModel() ~= gsModel ) then
+	  self:MakeGhostEntity( gsModel, Vector(0,0,0), Angle(0,0,0) )
 	end
 
 	self:UpdateGhostWireDupePort( self.GhostEntity, self:GetOwner() )

--- a/lua/weapons/gmod_tool/stools/wire_dupeport.lua
+++ b/lua/weapons/gmod_tool/stools/wire_dupeport.lua
@@ -15,40 +15,42 @@ if ( CLIENT ) then
 end
 
 if ( SERVER ) then
-	CreateConVar("sbox_maxwire_dupeports", 10)
+	CreateConVar( "sbox_maxwire_dupeports", 10 )
 end
 
 cleanup.Register( "wire_dupeports" )
 
 function TOOL:LeftClick( trace )
-	if trace.Entity and trace.Entity:IsPlayer() then return false end
+	if trace.Entity && trace.Entity:IsPlayer() then return false end
 	if ( CLIENT ) then return true end
 
 	local ply = self:GetOwner()
 
 	-- If we shot a wire_dupeport do nothing
-	if ( trace.Entity:IsValid() and trace.Entity:GetClass() == "gmod_wire_dupeport" and trace.Entity.pl == ply ) then
-		trace.Entity:Setup()
+	if ( trace.Entity:IsValid() &&
+			 trace.Entity.pl == ply &&
+			 trace.Entity:GetClass() == "gmod_wire_dupeport" ) then
+			 trace.Entity:Setup()
 		return true
 	end
 
-	if ( not self:GetSWEP():CheckLimit( "wire_dupeports" ) ) then return false end
+	if ( !self:GetSWEP():CheckLimit( "wire_dupeports" ) ) then return false end
 
 	local Ang = trace.HitNormal:Angle()
 	Ang.pitch = Ang.pitch + 90
 
 	local wire_dupeport = MakeWireDupePort( ply, Ang, trace.HitPos )
-	if ( not wire_dupeport ) then return false end
-	if ( not wire_dupeport:IsValid() ) then return false end
+	if ( !wire_dupeport ) then return false end
+	if ( !wire_dupeport:IsValid() ) then return false end
 
 	local min = wire_dupeport:OBBMins()
 	wire_dupeport:SetPos( trace.HitPos - trace.HitNormal * min.z )
 
-	local const = WireLib.Weld(wire_dupeport, trace.Entity, trace.PhysicsBone, true)
+	local weld = WireLib.Weld(wire_dupeport, trace.Entity, trace.PhysicsBone, true)
 
-	undo.Create("WireDupePort")
+	undo.Create( "WireDupePort" )
 		undo.AddEntity( wire_dupeport )
-		undo.AddEntity( const )
+		undo.AddEntity( weld )
 		undo.SetPlayer( ply )
 	undo.Finish()
 
@@ -60,18 +62,18 @@ end
 if ( SERVER ) then
 
 	function MakeWireDupePort( ply, Ang, Pos)
-		if ( ply:IsAdmin() or ply:IsSuperAdmin() ) then
+		if ( ply:IsAdmin() || ply:IsSuperAdmin() ) then
 
-			if ( not ply:CheckLimit( "wire_dupeports" ) ) then return false end
+			if ( !ply:CheckLimit( "wire_dupeports" ) ) then return false end
 
 			local wire_dupeport = ents.Create( "gmod_wire_dupeport" )
-			if ( not wire_dupeport:IsValid() ) then return false end
+			if ( !wire_dupeport:IsValid() ) then return false end
 
 			wire_dupeport:SetModel( Model( gsModel ) )
 			wire_dupeport:SetBeamLength( 100 )
 			wire_dupeport:SetAngles( Ang )
 			wire_dupeport:SetPos( Pos )
-			wire_dupeport:SetOverlayText("Adv. Dupe.Teleporter")
+			wire_dupeport:SetOverlayText( "Adv. Dupe.Teleporter" )
 			wire_dupeport:Spawn()
 
 			wire_dupeport:SetPlayer(ply)
@@ -88,24 +90,26 @@ if ( SERVER ) then
 
 			return wire_dupeport
 		else
-			ply:SendLua("GAMEMODE:AddNotify(\"A non-admin cannot spawn a Adv. Dupe Teleporter!\", NOTIFY_GENERIC, 5); surface.PlaySound(\"ambient/water/drip"..math.random(1, 4)..".wav\")")
+			ply:SendLua( "GAMEMODE:AddNotify(\"A non-admin cannot spawn a Adv. Dupe Teleporter!\", NOTIFY_GENERIC, 5); surface.PlaySound(\"ambient/water/drip"..math.random(1, 4)..".wav\")" )
 			return nil
 		end
 	end
 
-	duplicator.RegisterEntityClass("gmod_wire_dupeport", MakeWireDupePort, "Ang", "Pos")
+	duplicator.RegisterEntityClass( "gmod_wire_dupeport", MakeWireDupePort, "Ang", "Pos" )
 
 end
 
 function TOOL:UpdateGhostWireDupePort( ent, player )
-	if ( not ent ) then return end
-	if ( not ent:IsValid() ) then return end
+	if ( !ent ) then return end
+	if ( !ent:IsValid() ) then return end
 
 	local trace = player:GetEyeTrace()
-	if ( not trace.Hit ) then return end
+	if ( !trace.Hit ) then return end
 
-	if (trace.Entity and trace.Entity:IsValid() and
-		 (trace.Entity:GetClass() == "gmod_wire_dupeport" or trace.Entity:IsPlayer()) ) then
+	if ( trace.Entity &&
+		   trace.Entity:IsValid() &&
+		 ( trace.Entity:GetClass() == "gmod_wire_dupeport" ||
+		 	 trace.Entity:IsPlayer() ) ) then
 		ent:SetNoDraw( true )
 		return
 	end
@@ -122,9 +126,9 @@ end
 
 
 function TOOL:Think()
-	if ( not self.GhostEntity or
-			 not self.GhostEntity:IsValid() or
-					 self.GhostEntity:GetModel() ~= gsModel ) then
+	if ( !self.GhostEntity ||
+			 !self.GhostEntity:IsValid() ||
+			  self.GhostEntity:GetModel() ~= gsModel ) then
 		self:MakeGhostEntity( gsModel, Vector(0,0,0), Angle(0,0,0) )
 	end
 

--- a/lua/weapons/gmod_tool/stools/wire_dupeport.lua
+++ b/lua/weapons/gmod_tool/stools/wire_dupeport.lua
@@ -99,8 +99,7 @@ function TOOL:UpdateGhostWireDupePort( ent, player )
 	if ( !ent ) then return end
 	if ( !ent:IsValid() ) then return end
 
-	local tr 	= util.GetPlayerTrace( player, player:GetAimVector() )
-	local trace 	= util.TraceLine( tr )
+	local trace = player:GetEyeTrace()
 	if (!trace.Hit) then return end
 
 	if (trace.Entity && trace.Entity:GetClass() == "gmod_wire_dupeport" || trace.Entity:IsPlayer()) then

--- a/lua/weapons/gmod_tool/stools/wire_dupeport.lua
+++ b/lua/weapons/gmod_tool/stools/wire_dupeport.lua
@@ -1,13 +1,13 @@
 TOOL.Category		= "Wire Extras/Physics"
-TOOL.Name			= "Adv. Dupe. Teleporter"
+TOOL.Name				= "Adv. Dupe. Teleporter"
 TOOL.Command		= nil
-TOOL.ConfigName		= ""
-TOOL.Tab			= "Wire"
+TOOL.ConfigName	= ""
+TOOL.Tab				= "Wire"
 
 if ( CLIENT ) then
-    language.Add( "Tool.wire_dupeport.name", "Adv. Dupe. Teleporter Tool (Wire)" )
-    language.Add( "Tool.wire_dupeport.desc", "Spawns an Adv. Dupe. Teleporter for use with the wire system." )
-    language.Add( "Tool.wire_dupeport.0", "Primary: Create/Update Adv. Dupe. Teleporter" )
+	language.Add( "Tool.wire_dupeport.name", "Adv. Dupe. Teleporter Tool (Wire)" )
+	language.Add( "Tool.wire_dupeport.desc", "Spawns an Adv. Dupe. Teleporter for use with the wire system." )
+	language.Add( "Tool.wire_dupeport.0", "Primary: Create/Update Adv. Dupe. Teleporter" )
 	language.Add( "sboxlimit_wire_dupeports", "You've hit Adv. Dupe. Teleporters limit!" )
 	language.Add( "undone_wiredupeport", "Undone Wire Adv. Dupe. Teleporter" )
 end
@@ -24,7 +24,7 @@ function TOOL:LeftClick( trace )
 
 	local ply = self:GetOwner()
 
-	// If we shot a wire_dupeport do nothing
+	-- If we shot a wire_dupeport do nothing
 	if ( trace.Entity:IsValid() && trace.Entity:GetClass() == "gmod_wire_dupeport" && trace.Entity.pl == ply ) then
 		trace.Entity:Setup()
 		return true
@@ -35,7 +35,9 @@ function TOOL:LeftClick( trace )
 	local Ang = trace.HitNormal:Angle()
 	Ang.pitch = Ang.pitch + 90
 
-	wire_dupeport = MakeWireDupePort( ply, Ang, trace.HitPos )
+	local wire_dupeport = MakeWireDupePort( ply, Ang, trace.HitPos )
+	if(not wire_dupeport) then return false end
+	if(not wire_dupeport:IsValid()) then return false end
 
 	local min = wire_dupeport:OBBMins()
 	wire_dupeport:SetPos( trace.HitPos - trace.HitNormal * min.z )
@@ -57,12 +59,12 @@ if (SERVER) then
 
 	function MakeWireDupePort( ply, Ang, Pos)
 		if ply:IsAdmin() or ply:IsSuperAdmin() then
-		
+
 			if ( !ply:CheckLimit( "wire_dupeports" ) ) then return false end
 
 			local wire_dupeport = ents.Create( "gmod_wire_dupeport" )
 			if (!wire_dupeport:IsValid()) then return false end
-			
+
 			wire_dupeport:SetModel( Model("models/jaanus/wiretool/wiretool_speed.mdl") )
 			wire_dupeport:SetBeamLength(100)
 			wire_dupeport:SetAngles( Ang )
@@ -71,7 +73,7 @@ if (SERVER) then
 			wire_dupeport:Spawn()
 
 			wire_dupeport:SetPlayer(ply)
-			
+
 			if (game.SinglePlayer()) then
 				wire_dupeport.OwnerSteamID = ply
 				wire_dupeport.SpawnSteamID = ply


### PR DESCRIPTION
…uperadmin

The script assumes that the entity `wire_dupeport` will be always created globally correctly.