### PR TITLE
Adv. HUD Indicator was completely non-functional due to an oversight.

### DIFF
--- a/lua/entities/gmod_wire_adv_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_adv_hudindicator/init.lua
@@ -111,6 +111,9 @@ function ENT:HUDSetup(showinhud, huddesc, hudaddname, hudshowvalue, hudstyle, al
 			hudshowvalue = 1
 		end
 
+		self.HUDShowValue = hudshowvalue
+		self.HUDStyle = hudstyle
+
 		if (!self:CheckRegister(ply)) then
 			// First-time register
 			// Updating this player is handled further down


### PR DESCRIPTION
Fixed the Adv. HUD Indicator by defining two variables required by RegisterPlayer before it is first called.