### PR TITLE
Fixed Adv HUD indicator color and font error

### DIFF
--- a/lua/entities/gmod_wire_adv_hudindicator/cl_init.lua
+++ b/lua/entities/gmod_wire_adv_hudindicator/cl_init.lua
@@ -141,7 +141,7 @@ local function DrawAdvHUDIndicators()
 					elseif (indinfo.Style == 0) then
 						//--draw.WordBox(8, xPos, yPos, txt, "Default", Color(50, 50, 75, 192), Color(255, 255, 255, 255))
 
-						draw.DrawText( txt, "ScoreboardText", xPos, yPos, indinfo.DisplayColor, indinfo.TextColor )
+						draw.DrawText( txt, "ScoreboardDefault", xPos, yPos, indinfo.DisplayColor, indinfo.TextColor )
 
 
 					//-- Boxed Text (rounded corners...) --//

--- a/lua/entities/gmod_wire_adv_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_adv_hudindicator/init.lua
@@ -494,15 +494,14 @@ function ENT:TriggerInput(iname, value)
 	local force_position_update = 0
 
 	if (iname == "A") then
-		local factor = math.Clamp((value-self.A)/(self.B-self.A), 0, 1)
+		local factor = math.Clamp((value-self.A) / (self.B-self.A), 0, 1)
 		self:ShowOutput(factor, value)
 
-		//--local r = math.Clamp((self.BR-self.AR)*factor+self.AR, 0, 255)
-		//--local g = math.Clamp((self.BG-self.AG)*factor+self.AG, 0, 255)
-		//--local b = math.Clamp((self.BB-self.AB)*factor+self.AB, 0, 255)
-		//--local a = math.Clamp((self.BA-self.AA)*factor+self.AA, 0, 255)
-		//--self:SetColor(r, g, b, a)
-		self:SetColor(Color(255, 255, 255, 255))
+		local r = math.Clamp((self.BR-self.AR) * factor + self.AR, 0, 255)
+		local g = math.Clamp((self.BG-self.AG) * factor + self.AG, 0, 255)
+		local b = math.Clamp((self.BB-self.AB) * factor + self.AB, 0, 255)
+		local a = math.Clamp((self.BA-self.AA) * factor + self.AA, 0, 255)
+		self:SetColor(Color(r, g, b, a))
 	elseif (iname == "HideHUD") then
 		if (self.PrevHideHUD == (value > 0)) then return end
 


### PR DESCRIPTION
This simple fix should solve the Adv HUD indicator white color issue and the errors that appeared in the console. If nothing else is broken (it seems that everything is working fine btw) I guess it fixes #107.