### PR TITLE
Parity with wiremod/wire#2399

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/camera.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/camera.lua
@@ -140,13 +140,13 @@ __e2setcost( 10 )
 e2function void cameraPos( index, vector position )
 	local camera = GetCamera( self, index )
 	if not camera then return end
-	camera:SetPos( Vector(position[1],position[2],position[3]) )
+	camera:SetPos(position)
 end
 
 __e2setcost( 2 )
 e2function vector cameraPos( index )
 	local camera = GetCamera( self, index )
-	if not camera then return {0,0,0} end
+	if not camera then return Vector(0,0,0) end
 	return camera:GetPos()
 end
 
@@ -155,15 +155,14 @@ __e2setcost( 10 )
 e2function void cameraAng( index, angle ang )
 	local camera = GetCamera( self, index )
 	if not camera then return end
-	camera:SetAngles( Angle(ang[1],ang[2],ang[3]) )
+	camera:SetAngles(ang)
 end
 
 __e2setcost( 2 )
 e2function angle cameraAng( index )
 	local camera = GetCamera( self, index )
-	if not camera then return {0,0,0} end
-	local ang = camera:GetAngles()
-	return {ang.p, ang.y, ang.r}
+	if not camera then return Angle(0, 0, 0) end
+	return camera:GetAngles()
 end
 
 -----------------

--- a/lua/entities/gmod_wire_expression2/core/custom/ftrace.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/ftrace.lua
@@ -138,45 +138,61 @@ end, varDefPrint:GetName().."_call")
 --[[ **************************** WRAPPERS **************************** ]]
 
 local function convertDirLocal(oFTrc, vE, vA)
-	if(not oFTrc) then return {0,0,0} end
+	if(not oFTrc) then return Vector(0, 0, 0) end
 	local oD, oE = oFTrc.mDir, (vE or oFTrc.mEnt)
-	if(not (isValid(oE) or vA)) then return {oD[1], oD[2], oD[3]} end
-	local oA = Angle(); if(vA) then
+	if(not (isValid(oE) or vA)) then return oD end
+
+	local oA = Angle()
+	if(vA) then
 		oA:SetUnpacked(vA[1], vA[2], vA[3])
-	else oA:Set(oE:GetAngles()) end; local oV = Vector(oD)
-	return {oV:Dot(oA:Forward()), -oV:Dot(oA:Right()), oV:Dot(oA:Up())}
+	else
+		oA:Set(oE:GetAngles())
+	end
+
+	local oV = Vector(oD)
+	return Vector( oV:Dot(oA:Forward()), -oV:Dot(oA:Right()), oV:Dot(oA:Up()) )
 end -- Gmod +Y is the left direction
 
 local function convertDirWorld(oFTrc, vE, vA)
-	if(not oFTrc) then return {0,0,0} end
+	if(not oFTrc) then return Vector(0, 0, 0) end
 	local oD, oE = oFTrc.mDir, (vE or oFTrc.mEnt)
-	if(not (isValid(oE) or vA)) then return {oD[1], oD[2], oD[3]} end
-	local oA = Angle(); if(vA) then
+
+	if(not (isValid(oE) or vA)) then return oD end
+	local oA = Angle()
+
+	if(vA) then
 		oA:SetUnpacked(vA[1], vA[2], vA[3])
-	else oA:Set(oE:GetAngles()) end; local oV = Vector(oD)
-	oV:Rotate(oA); return {oV[1], oV[2], oV[3]}
+	else
+		oA:Set(oE:GetAngles())
+	end
+
+	local oV = Vector(oD)
+	oV:Rotate(oA)
+
+	return oV
 end
 
 local function convertOrgEnt(oFTrc, sF, vE)
-	if(not oFTrc) then return {0,0,0} end
-	if(not gtConvEnab[sF or gsZeroStr]) then return {0,0,0} end
+	if(not oFTrc) then return Vector(0, 0, 0) end
+	if(not gtConvEnab[sF or gsZeroStr]) then return Vector(0, 0, 0) end
 	local oO, oE = oFTrc.mPos, (vE or oFTrc.mEnt)
-	if(not isValid(oE)) then return {oO[1], oO[2], oO[3]} end
+	if(not isValid(oE)) then return oO end
 	local oV = Vector(oO); oV:Set(oE[sF](oE, oV))
-	return {oV:Unpack()}
+	return oV
 end
 
 local function convertOrgUCS(oFTrc, sF, vP, vA)
-	if(not oFTrc) then return {0,0,0} end
-	if(not gtConvEnab[sF or gsZeroStr]) then return {0,0,0} end
+	if(not oFTrc) then return Vector(0, 0, 0) end
+	if(not gtConvEnab[sF or gsZeroStr]) then return Vector(0, 0, 0) end
 	local oO, oE = oFTrc.mPos, (vE or oFTrc.mEnt)
-	if(not isValid(oE)) then return {oO[1], oO[2], oO[3]} end
+	if(not isValid(oE)) then return oO end
 	local oV, oA = Vector(oO), Angle()
 	local uP, uA = gvTransform, gaTransform
 	uP:SetUnpacked(vP[1], vP[2], vP[3])
 	uA:SetUnpacked(vA[1], vA[2], vA[3])
 	local vN, aN = gtConvEnab[sF](oV, oA, uP, uA); oV:Set(vN)
-	return {oV:Unpack()}
+
+	return oV
 end
 
 local function vecMultiply(vV, nX, nY, nZ)
@@ -642,28 +658,28 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:useUnit(ftrace oT)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not oT) then return this end
 	this.mTrI.filter = oT.mFlt.Enu; return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:useArray(ftrace oT)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not oT) then return this end
 	this.mTrI.filter = oT.mFlt.Ear; return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:useAction(ftrace oT)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not oT) then return this end
 	this.mTrI.filter = oT.mFlt.Fnc; return this
 end
 
 __e2setcost(12)
 e2function ftrace ftrace:cpyArray(ftrace oT)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not oT) then return this end
 	return putFilterEar(this, oT.mFlt.Ear, false, false)
 end
@@ -682,25 +698,25 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:remFilter()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mTrI.filter = nil; return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:useArray()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mTrI.filter = this.mFlt.Ear; return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:useUnit()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mTrI.filter = this.mFlt.Enu; return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:useAction()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mTrI.filter = this.mFlt.Fnc; return this
 end
 
@@ -708,20 +724,20 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:putUnit(entity vE)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not isValid(vE)) then return this end
 	this.mFlt.Enu = vE; return this
 end
 
 __e2setcost(3)
 e2function entity ftrace:getUnit()
-	if(not this) then return nil end
+	if not this then return nil end
 	return this.mFlt.Enu
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:remUnit()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mFlt.Enu = nil; return this
 end
 
@@ -729,7 +745,7 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:putActionSkipEnt(entity vE)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not isValid(vE)) then return this end
 	this.mFnc.Ent.SKIP[vE] = true; return this
 end
@@ -738,7 +754,7 @@ e2function ftrace ftrace:addEntHitSkip(entity vE) = e2function ftrace ftrace:put
 
 __e2setcost(3)
 e2function ftrace ftrace:remActionSkipEnt(entity vE)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not isValid(vE)) then return this end
 	this.mFnc.Ent.SKIP[vE] = nil; return this
 end
@@ -747,7 +763,7 @@ e2function ftrace ftrace:remEntHitSkip(entity vE) = e2function ftrace ftrace:rem
 
 __e2setcost(3)
 e2function ftrace ftrace:remActionSkipEnt()
-	if(not this) then return nil end
+	if not this then return nil end
 	table.Empty(this.mFnc.Ent.SKIP); return this
 end
 
@@ -755,7 +771,7 @@ e2function ftrace ftrace:remEntHitSkip() = e2function ftrace ftrace:remActionSki
 
 __e2setcost(3)
 e2function ftrace ftrace:putActionOnlyEnt(entity vE)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not isValid(vE)) then return this end
 	this.mFnc.Ent.ONLY[vE] = true; return this
 end
@@ -764,7 +780,7 @@ e2function ftrace ftrace:addEntHitOnly(entity vE) = e2function ftrace ftrace:put
 
 __e2setcost(3)
 e2function ftrace ftrace:remActionOnlyEnt(entity vE)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not isValid(vE)) then return this end
 	this.mFnc.Ent.ONLY[vE] = nil; return this
 end
@@ -773,7 +789,7 @@ e2function ftrace ftrace:remEntHitOnly(entity vE) = e2function ftrace ftrace:rem
 
 __e2setcost(3)
 e2function ftrace ftrace:remActionOnlyEnt()
-	if(not this) then return nil end
+	if not this then return nil end
 	table.Empty(this.mFnc.Ent.ONLY); return this
 end
 
@@ -781,7 +797,7 @@ e2function ftrace ftrace:remEntHitOnly() = e2function ftrace ftrace:remActionOnl
 
 __e2setcost(3)
 e2function ftrace ftrace:remActionEnt()
-	if(not this) then return nil end
+	if not this then return nil end
 	table.Empty(this.mFnc.Ent.SKIP)
 	table.Empty(this.mFnc.Ent.ONLY); return this
 end
@@ -832,7 +848,7 @@ end
 
 __e2setcost(3)
 e2function number ftrace:getArraySZ()
-	if(not this) then return nil end
+	if not this then return nil end
 	return this.mFlt.Size
 end
 
@@ -845,14 +861,14 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:remArrayN(number iN)
-	if(not this) then return nil end
+	if not this then return nil end
 	table.remove(this.mFlt.Ear, math.floor(iN))
 	return updateEarSize(this)
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:remArrayID(number iE)
-	if(not this) then return nil end
+	if not this then return nil end
 	local tE = this.mFlt.Ear
 	local vE = Entity(math.floor(iE))
 	local iN = table.KeyFromValue(tE, vE)
@@ -862,7 +878,7 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:remArray(entity vE)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not isValid(vE)) then return this end
 	local tE = this.mFlt.Ear
 	local iN = table.KeyFromValue(tE, vE)
@@ -872,7 +888,7 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:remArray()
-	if(not this) then return nil end
+	if not this then return nil end
 	table.Empty(this.mFlt.Ear)
 	return updateEarSize(this)
 end
@@ -881,7 +897,7 @@ end
 
 __e2setcost(12)
 e2function ftrace ftrace:remAction()
-	if(not this) then return nil end
+	if not this then return nil end
 	local tID = this.mFnc.ID
 	for key, id in pairs(tID) do
 		removeFncFilter(this, key)
@@ -899,13 +915,13 @@ e2function ftrace ftrace:remHit(string sM) = e2function ftrace ftrace:remAction(
 
 __e2setcost(3)
 e2function ftrace ftrace:remActionSkip(string sM)
-	if(not this) then return nil end
+	if not this then return nil end
 	return removeFncFilterOption(this, sM, "SKIP")
 end
 
 __e2setcost(9)
 e2function ftrace ftrace:remActionSkip()
-	if(not this) then return nil end
+	if not this then return nil end
 	local tID = this.mFnc.ID
 	for key, id in pairs(tID) do
 		removeFncFilterOption(this, key, "SKIP")
@@ -914,13 +930,13 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:remActionOnly(string sM)
-	if(not this) then return nil end
+	if not this then return nil end
 	return removeFncFilterOption(this, sM, "ONLY")
 end
 
 __e2setcost(9)
 e2function ftrace ftrace:remActionOnly()
-	if(not this) then return nil end
+	if not this then return nil end
 	local tID = this.mFnc.ID
 	for key, id in pairs(tID) do
 		removeFncFilterOption(this, key, "ONLY")
@@ -991,104 +1007,104 @@ e2function ftrace ftrace:remHitOnly(string sM, string vS) = e2function ftrace ft
 
 __e2setcost(3)
 e2function ftrace ftrace:rayMove()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mPos:Add(this.mDir); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayMove(number nL)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = this.mDir:GetNormalized()
 	vD:Mul(nL); this.mPos:Add(vD); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayMove(vector vV)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = Vector(vV[1], vV[2], vV[3])
 	this.mPos:Add(vD); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayMove(number nX, number nY, number nZ)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = Vector(nX, nY, nZ)
 	this.mPos:Add(vD); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayMove(vector vV, number nL)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = Vector(vV[1], vV[2], vV[3])
 	vD:Normalize(); vD:Mul(nL); this.mPos:Add(vD); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayAmend(vector vV)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = Vector(vV[1], vV[2], vV[3])
 	this.mDir:Add(vD); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayAmend(number nX, number nY, number nZ)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = Vector(nX, nY, nZ)
 	this.mDir:Add(vD); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayAmend(vector vV, number nL)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = Vector(vV[1], vV[2], vV[3])
 	vD:Normalize(); vD:Mul(nL); this.mDir:Add(vD); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayMul(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mLen = this.mLen * nN; this.mDir:Normalize()
 	this.mDir:Mul(this.mLen); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayMul(vector vV)
-	if(not this) then return nil end
+	if not this then return nil end
 	vecMultiply(this.mDir, vV[1], vV[2], vV[3])
 	this.mLen = this.mDir:Length(); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayMul(number nX, number nY, number nZ)
-	if(not this) then return nil end
+	if not this then return nil end
 	vecMultiply(this.mDir, nX, nY, nZ)
 	this.mLen = this.mDir:Length(); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayDiv(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mLen = this.mLen / nN; this.mDir:Normalize()
 	this.mDir:Mul(this.mLen); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayDiv(vector vV)
-	if(not this) then return nil end
+	if not this then return nil end
 	vecDivide(this.mDir, vV[1], vV[2], vV[3])
 	this.mLen = this.mDir:Length(); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayDiv(number nX, number nY, number nZ)
-	if(not this) then return nil end
+	if not this then return nil end
 	vecDivide(this.mDir, nX, nY, nZ)
 	this.mLen = this.mDir:Length(); return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayAim(vector vV)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = Vector(vV[1], vV[2], vV[3])
 	vD:Sub(this.mPos); vD:Normalize()
 	vD:Mul(this.mLen); this.mDir:Set(vD)
@@ -1097,7 +1113,7 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:rayAim(number nX, number nY, number nZ)
-	if(not this) then return nil end
+	if not this then return nil end
 	local vD = Vector(nX, nY, nZ)
 	vD:Sub(this.mPos); vD:Normalize()
 	vD:Mul(this.mLen); this.mDir:Set(vD)
@@ -1108,14 +1124,14 @@ end
 
 __e2setcost(3)
 e2function entity ftrace:getChip()
-	if(not this) then return nil end;
+	if not this then return nil end;
 	local vE = this.mChip.entity
 	if(not isValid(vE)) then return nil end; return vE
 end
 
 __e2setcost(3)
 e2function entity ftrace:getPlayer()
-	if(not this) then return nil end;
+	if not this then return nil end;
 	local vE = this.mChip.player
 	if(not isValid(vE)) then return nil end; return vE
 end
@@ -1124,20 +1140,20 @@ end
 
 __e2setcost(3)
 e2function entity ftrace:getBase()
-	if(not this) then return nil end; local vE = this.mEnt
+	if not this then return nil end; local vE = this.mEnt
 	if(not isValid(vE)) then return nil end; return vE
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:setBase(entity eE)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(not isValid(eE)) then return this end
 	this.mEnt = eE; return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:remBase()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mEnt = nil; return this
 end
 
@@ -1145,20 +1161,20 @@ end
 
 __e2setcost(3)
 e2function number ftrace:isIgnoreWorld()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mTrI.ignoreworld and 1 or 0)
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:setIsIgnoreWorld(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mTrI.ignoreworld = (nN ~= 0); return this
 end
 
 __e2setcost(3)
 e2function vector ftrace:getPos()
-	if(not this) then return {0,0,0} end
-	return {this.mPos:Unpack()}
+	if not this then return Vector(0, 0, 0) end
+	return this.mPos
 end
 
 __e2setcost(3)
@@ -1193,29 +1209,29 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:setPos(array aO)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mPos:SetUnpacked(aO[1], aO[2], aO[3])
 	return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:setPos(vector vO)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mPos:SetUnpacked(vO[1], vO[2], vO[3])
 	return this
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:setPos(number nX, number nY, number nZ)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mPos:SetUnpacked(nX, nY, nZ)
 	return this
 end
 
 __e2setcost(3)
 e2function vector ftrace:getDir()
-	if(not this) then return nil end
-	return {this.mDir:Unpack()}
+	if not this then return nil end
+	return this.mDir
 end
 
 __e2setcost(3)
@@ -1250,7 +1266,7 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:setDir(array aD)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mDir:SetUnpacked(aD[1], aD[2], aD[3])
 	this.mDir:Normalize(); this.mDir:Mul(this.mLen)
 	return this
@@ -1258,7 +1274,7 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:setDir(vector vD)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mDir:SetUnpacked(vD[1], vD[2], vD[3])
 	this.mDir:Normalize(); this.mDir:Mul(this.mLen)
 	return this
@@ -1266,7 +1282,7 @@ end
 
 __e2setcost(3)
 e2function ftrace ftrace:setDir(number nX, number nY, number nZ)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mDir:SetUnpacked(nX, nY, nZ)
 	this.mDir:Normalize(); this.mDir:Mul(this.mLen)
 	return this
@@ -1274,13 +1290,13 @@ end
 
 __e2setcost(3)
 e2function number ftrace:getLen()
-	if(not this) then return nil end
+	if not this then return nil end
 	return (this.mLen or 0)
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:setLen(number nL)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mLen = math.Clamp(nL,-gnMaxBeam,gnMaxBeam)
 	this.mDir:Normalize(); this.mDir:Mul(this.mLen)
 	this.mLen = math.abs(this.mLen); return this
@@ -1288,40 +1304,38 @@ end
 
 __e2setcost(3)
 e2function number ftrace:getMask()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mTrI.mask or 0)
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:setMask(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mTrI.mask = nN; return this
 end
 
 __e2setcost(3)
 e2function number ftrace:getCollideGroup()
-	if(not this) then return nil end
+	if not this then return nil end
 	return (this.mTrI.collisiongroup or 0)
 end
 
 __e2setcost(3)
 e2function ftrace ftrace:setCollideGroup(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mTrI.collisiongroup = nN; return this
 end
 
 __e2setcost(3)
 e2function vector ftrace:getStart()
-	if(not this) then return {0,0,0} end
-	local vT = this.mTrI.start
-	return {vT:Unpack()}
+	if not this then return Vector(0, 0, 0) end
+	return this.mTrI.start
 end
 
 __e2setcost(3)
 e2function vector ftrace:getStop()
-	if(not this) then return {0,0,0} end
-	local vT = this.mTrI.endpos
-	return {vT:Unpack()}
+	if not this then return Vector(0, 0, 0) end
+	return this.mTrI.endpos
 end
 
 __e2setcost(12)
@@ -1396,98 +1410,94 @@ end
 
 __e2setcost(3)
 e2function number ftrace:isHitNoDraw()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.HitNoDraw
 	return (trV and 1 or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:isHitNonWorld()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.HitNonWorld
 	return (trV and 1 or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:isHit()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.Hit
 	return (trV and 1 or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:isHitSky()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.HitSky
 	return (trV and 1 or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:isHitWorld()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.HitWorld
 	return (trV and 1 or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:getHitBox()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.HitBox
 	return (trV and trV or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:getMatType()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.MatType
 	return (trV and trV or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:getHitGroup()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.HitGroup
 	return (trV and trV or 0)
 end
 
 __e2setcost(8)
 e2function vector ftrace:getHitPos()
-	if(not this) then return {0,0,0} end
-	local trV = this.mTrO.HitPos
-	return (trV and {trV:Unpack()} or {0,0,0})
+	if not this then return Vector(0, 0, 0) end
+	return this.mTrO.HitPos
 end
 
 __e2setcost(8)
 e2function vector ftrace:getHitNormal()
-	if(not this) then return {0,0,0} end
-	local trV = this.mTrO.HitNormal
-	return (trV and {trV:Unpack()} or {0,0,0})
+	if not this then return Vector(0, 0, 0) end
+	return this.mTrO.HitNormal
 end
 
 __e2setcost(8)
 e2function vector ftrace:getNormal()
-	if(not this) then return {0,0,0} end
-	local trV = this.mTrO.Normal
-	return (trV and {trV:Unpack()} or {0,0,0})
+	if not this then return Vector(0, 0, 0) end
+	return this.mTrO.Normal
 end
 
 __e2setcost(8)
 e2function string ftrace:getHitTexture()
-	if(not this) then return gsZeroStr end
+	if not this then return gsZeroStr end
 	local trV = this.mTrO.HitTexture
 	return tostring(trV or gsZeroStr)
 end
 
 __e2setcost(8)
 e2function vector ftrace:getStartPos()
-	if(not this) then return {0,0,0} end
-	local trV = this.mTrO.StartPos
-	return (trV and {trV:Unpack()} or {0,0,0})
+	if not this then return Vector(0, 0, 0) end
+	return this.mTrO.StartPos
 end
 
 __e2setcost(3)
 e2function number ftrace:getSurfacePropsID()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.SurfaceProps
 	return (trV and trV or 0)
 end
@@ -1496,7 +1506,7 @@ e2function number ftrace:getSurfPropsID() = e2function number ftrace:getSurfaceP
 
 __e2setcost(3)
 e2function string ftrace:getSurfacePropsName()
-	if(not this) then return gsZeroStr end
+	if not this then return gsZeroStr end
 	local trV = this.mTrO.SurfaceProps
 	return (trV and util.GetSurfacePropName(trV) or gsZeroStr)
 end
@@ -1505,70 +1515,70 @@ e2function string ftrace:getSurfPropsName() = e2function string ftrace:getSurfac
 
 __e2setcost(3)
 e2function number ftrace:getPhysicsBoneID()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.PhysicsBone
 	return (trV and trV or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:getFraction()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.Fraction
 	return (trV and trV or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:getFractionLen()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.Fraction
 	return (trV and (trV * this.mLen) or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:isStartSolid()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.StartSolid
 	return (trV and 1 or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:isAllSolid()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.AllSolid
 	return (trV and 1 or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:getFractionLS()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.FractionLeftSolid
 	return (trV and trV or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:getFractionLenLS()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.FractionLeftSolid
 	return (trV and (trV * this.mLen) or 0)
 end
 
 __e2setcost(3)
 e2function entity ftrace:getEntity()
-	if(not this) then return nil end
+	if not this then return nil end
 	local trV = this.mTrO.Entity
 	return (trV and trV or nil)
 end
 
 __e2setcost(3)
 e2function number ftrace:getSurfaceFlags()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.SurfaceFlags
 	return (trV and trV or 0)
 end
 
 __e2setcost(3)
 e2function number ftrace:getDispFlags()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.DispFlags
 	return (trV and trV or 0)
 end
@@ -1578,7 +1588,7 @@ e2function number ftrace:getDisplacementFlags() = e2function number ftrace:getDi
 
 __e2setcost(3)
 e2function number ftrace:getContents()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local trV = this.mTrO.Contents
 	return (trV and trV or 0)
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/light.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/light.lua
@@ -58,7 +58,7 @@ local function CreateLight( self, index, position, color, distance, brightness )
 	local light = GetLight( self, index )
 	if light and light:IsValid() then
 		if position then
-			light:SetPos( Vector(position[1],position[2],position[3]) )
+			light:SetPos(position)
 		end
 		
 		if color then
@@ -144,7 +144,7 @@ end
 __e2setcost( 5 )
 e2function vector lightPos( index )
 	local light = GetLight( self, index )
-	if not light then return {0,0,0} end
+	if not light then return Vector(0, 0, 0) end
 	return light:GetPos()
 end
 
@@ -160,8 +160,8 @@ end
 __e2setcost( 5 )
 e2function vector lightColor( index )
 	local light = GetLight( self, index )
-	if not light then return {0,0,0} end
-	return {color[1],color[2],color[3]}
+	if not light then return Vector(0, 0, 0) end
+	return Vector(color[1],color[2],color[3])
 end
 
 -----------------

--- a/lua/entities/gmod_wire_expression2/core/custom/stcontrol.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/stcontrol.lua
@@ -573,79 +573,79 @@ end
 
 __e2setcost(3)
 e2function array stcontrol:getGain()
-	if(not this) then return {0,0,0} end
+	if not this then return {0,0,0} end
 	return {this.mkP, this.mkI, this.mkD}
 end
 
 __e2setcost(3)
 e2function vector stcontrol:getGain()
-	if(not this) then return {0,0,0} end
-	return {this.mkP, this.mkI, this.mkD}
+	if not this then return Vector(0, 0, 0) end
+	return Vector(this.mkP, this.mkI, this.mkD)
 end
 
 __e2setcost(3)
 e2function array stcontrol:getGainPI()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mkP, this.mkI}
 end
 
 __e2setcost(3)
 e2function vector2 stcontrol:getGainPI()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mkP, this.mkI}
 end
 
 __e2setcost(3)
 e2function array stcontrol:getGainPD()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mkP, this.mkD}
 end
 
 __e2setcost(3)
 e2function vector2 stcontrol:getGainPD()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mkP, this.mkD}
 end
 
 __e2setcost(3)
 e2function array stcontrol:getGainID()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mkI, this.mkD}
 end
 
 __e2setcost(3)
 e2function vector2 stcontrol:getGainID()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mkI, this.mkD}
 end
 
 __e2setcost(3)
 e2function number stcontrol:getGainP()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mkP or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getGainI()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mkI or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getGainD()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mkD or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setBias(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mBias = nN; return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:getBias()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mBias or 0)
 end
 
@@ -656,76 +656,76 @@ end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setWindup(number nD, number nU)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(nD < nU) then this.mSatD, this.mSatU = nD, nU end
 	return this
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setWindup(array aA)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(aA[1] < aA[2]) then this.mSatD, this.mSatU = aA[1], aA[2] end
 	return this
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setWindup(vector2 vV)
-	if(not this) then return nil end
+	if not this then return nil end
 	if(vV[1] < vV[2]) then this.mSatD, this.mSatU = vV[1], vV[2] end
 	return this
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setWindupMin(number nD)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mSatD = nD; return this
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setWindupMax(number nU)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mSatU = nU; return this
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:remWindup()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mSatD = nil; this.mSatU = nil; return this
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:remWindupMin()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mSatD = nil; return this
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:remWindupMax()
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mSatU = nil; return this
 end
 
 __e2setcost(3)
 e2function array stcontrol:getWindup()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mSatD, this.mSatU}
 end
 
 __e2setcost(3)
 e2function vector2 stcontrol:getWindup()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mSatD, this.mSatU}
 end
 
 __e2setcost(3)
 e2function number stcontrol:getWindupMin()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mSatD or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getWindupMax()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mSatU or 0)
 end
 
@@ -806,135 +806,135 @@ end
 
 __e2setcost(3)
 e2function array stcontrol:getPower()
-	if(not this) then return {0,0,0} end
+	if not this then return {0,0,0} end
 	return {this.mpP, this.mpI, this.mpD}
 end
 
 __e2setcost(3)
 e2function vector stcontrol:getPower()
-	if(not this) then return {0,0,0} end
-	return {this.mpP, this.mpI, this.mpD}
+	if not this then return Vector(0, 0, 0) end
+	return Vector(this.mpP, this.mpI, this.mpD)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getPowerP()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mpP or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getPowerI()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mpI or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getPowerD()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mpD or 0)
 end
 
 __e2setcost(3)
 e2function array stcontrol:getPowerPI()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mpP, this.mpI}
 end
 
 __e2setcost(3)
 e2function vector2 stcontrol:getPowerPI()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mpP, this.mpI}
 end
 
 __e2setcost(3)
 e2function array stcontrol:getPowerPD()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mpP, this.mpD}
 end
 
 __e2setcost(3)
 e2function vector2 stcontrol:getPowerPD()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mpP, this.mpD}
 end
 
 __e2setcost(3)
 e2function array stcontrol:getPowerID()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mpI, this.mpD}
 end
 
 __e2setcost(3)
 e2function vector2 stcontrol:getPowerID()
-	if(not this) then return {0,0} end
+	if not this then return {0,0} end
 	return {this.mpI, this.mpD}
 end
 
 
 __e2setcost(3)
 e2function number stcontrol:getErrorNow()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mErrN or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getErrorPast()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mErrO or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getErrorDelta()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mErrN - this.mErrO)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getTimeNow()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mTimN or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getTimePast()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mTimO or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getTimeDelta()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return ((this.mTimN or 0) - (this.mTimO or 0))
 end
 
 __e2setcost(3)
 e2function number stcontrol:getTimeSample()
-	if(not this) then return 0 end; local nT = this.mnTo
+	if not this then return 0 end; local nT = this.mnTo
 	return ((nT and nT > 0) and nT or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setTimeSample(number nT)
-	if(not this) then return 0 end
+	if not this then return 0 end
 	this.mnTo = ((nT and nT > 0) and nT or nil)
 	return this
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:remTimeSample()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	this.mnTo = nil; return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:getTimeBench()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mTimB or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getTimeRatio()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	local timDt = (this.mTimN - this.mTimO)
 	if(timDt == 0) then return 0 end
 	return ((this.mTimB or 0) / timDt)
@@ -942,133 +942,133 @@ end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setIsIntegral(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.meInt = (nN ~= 0); return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:isIntegral()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.meInt and 1 or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setIsDerivative(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.meDif = (nN ~= 0); return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:isDerivative()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.meDif and 1 or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setIsZeroCross(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.meZcx = (nN ~= 0); return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:isZeroCross()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.meZcx and 1 or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setIsCombined(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mbCmb = (nN ~= 0); return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:isCombined()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mbCmb and 1 or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setIsManual(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mbMan = (nN ~= 0); return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:isManual()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mbMan and 1 or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setManual(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mvMan = nN; return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:getManual()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mvMan or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setIsInverted(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mbInv = (nN ~= 0); return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:isInverted()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mbInv and 1 or 0)
 end
 
 __e2setcost(3)
 e2function stcontrol stcontrol:setIsActive(number nN)
-	if(not this) then return nil end
+	if not this then return nil end
 	this.mbOn = (nN ~= 0); return this
 end
 
 __e2setcost(3)
 e2function number stcontrol:isActive()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mbOn and 1 or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getControl()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mvCon or 0)
 end
 
 __e2setcost(3)
 e2function array stcontrol:getControlTerm()
-	if(not this) then return {0,0,0} end
+	if not this then return {0,0,0} end
 	return {this.mvP, this.mvI, this.mvD}
 end
 
 __e2setcost(3)
 e2function vector stcontrol:getControlTerm()
-	if(not this) then return {0,0,0} end
-	return {this.mvP, this.mvI, this.mvD}
+	if not this then return Vector(0, 0, 0) end
+	return Vector(this.mvP, this.mvI, this.mvD)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getControlTermP()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mvP or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getControlTermI()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mvI or 0)
 end
 
 __e2setcost(3)
 e2function number stcontrol:getControlTermD()
-	if(not this) then return 0 end
+	if not this then return 0 end
 	return (this.mvD or 0)
 end
 
@@ -1079,7 +1079,7 @@ end
 
 __e2setcost(20)
 e2function stcontrol stcontrol:setState(number nR, number nO)
-	if(not this) then return nil end
+	if not this then return nil end
 	return conProcess(this, nR, nO)
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/tracesystem.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/tracesystem.lua
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+--[[***********************************************************************************************************************
 Credits
 
 
@@ -7,13 +7,13 @@ Feha - I am coding the stuff
 gmod lua wiki - they got a list of functions you can use.
 
 Inspired by the e2 extensions: holo, datasignals, gvars, entity and ranger.
-***********************************************************************************************************************/
+***********************************************************************************************************************]]
 
 E2Lib.RegisterExtension("tracesystem", false)
 
-/****************************
+--[[****************************
 *****     Helper functions     *****
-****************************/
+****************************]]
 
 --[
 local v = debug.getregistry().Vector
@@ -24,133 +24,105 @@ local Distance = v.Distance
 local sqrt = math.sqrt
 --]]
 
-local function E2VecToLuaVec( Vec )
-	
-	return Vector(Vec[1],Vec[2],Vec[3])
-	
-end
-
-local function LuaVecToE2Vec( Vec )
-	
-	if (Vec) then return {Vec.x,Vec.y,Vec.z} end
-	
-	return {0,0,0}
-	
-end
-
-local function E2AngToLuaAng( Ang )
-	
-	return Angle(Ang[1],Ang[2],Ang[3])
-	
-end
-
-local function LuaAngToE2Ang( Ang )
-	
-	if (Ang) then return {Ang.p,Ang.y,Ang.r} end
-	
-	return {0,0,0}
-	
-end
-
-//Default function make 1,0,0 have a length below 1, use this instead.
+-- Default function make 1,0,0 have a length below 1, use this instead.
 local function Norm( Vec )
-	
+
 	return Vec / Length(Vec)
-	
+
 end
 
 
 
-/*********************************
+--[[*********************************
 *****     Intersection functions     *****
-*********************************/
+*********************************]]
 
 local function RayPlaneIntersection( Start, Dir, Pos, Normal )
-	
+
 	local A = Dot(Normal, Dir)
-	
-	//Check if the ray is aiming towards the plane (fail if it origin behind the plane, but that is checked later)
+
+	-- Check if the ray is aiming towards the plane (fail if it origin behind the plane, but that is checked later)
 	if (A < 0) then
-		
+
 		local B = Dot(Normal, Pos-Start)
-		
-		//Check if the ray origin in front of plane
+
+		-- Check if the ray origin in front of plane
 		if (B < 0) then
 			return (Start + Dir * (B/A))
 		end
-		
-	//Check if the ray is parallel to the plane
+
+	-- Check if the ray is parallel to the plane
 	elseif (A == 0) then
-		
-		//Check if the ray origin inside the plane
+
+		-- Check if the ray origin inside the plane
 		if (Dot(Normal, Pos-Start) == 0) then
 			return Start
 		end
-		
+
 	end
-	
+
 	return false
-	
+
 end
 
 local function RayFaceIntersection( Start, Dir, Pos, Normal, Size, Rotation )
-	
+
 	local hitPos = RayPlaneIntersection( Start, Dir, Pos, Normal )
-	
+
 	if (hitPos) then
-		
+
 		faceAngle = Normal:Angle()+Angle(0,0,Rotation)
-		
+
 		local localHitPos = WorldToLocal( hitPos, Angle(0,0,0), Pos, faceAngle )
-		
+
 		local min = Size/-2
 		local max = Size/2
-		
-		//Because using Normal:Angle() for WorldToLocal() makes it think that axis is x, we need to use the local hitpos z as x.
+
+		-- Because using Normal:Angle() for WorldToLocal() makes it think that axis is x, we need to use the local hitpos z as x.
 		if (localHitPos.z >= min.x and localHitPos.z <= max.x) then
 			if (localHitPos.y >= min.y and localHitPos.y <= max.y) then
-				
+
 				return hitPos
-				
+
 			end
 		end
-		
+
 	end
-	
+
 	return false
-	
+
 end
 
 local function RayPolygonIntersection( Start, Dir, Vertices )
-	
+
 	local Vertex1 = Vertices[1]
 	local Vertex2 = Vertices[2]
 	local Vertex3 = Vertices[3]
-	
+
 	local V1V2 = Norm(Vertex2 - Vertex1)
 	local V1V3 = Norm(Vertex3 - Vertex1)
-	
+
 	local normal = Cross(V1V2, V1V3)
 	if Dot( Dir, normal ) > 0 then normal:Mul(-1) end
-	
+
 	local hitPos = RayPlaneIntersection( Start, Dir, Vertex1, normal )
-	
+
 	if (hitPos) then
-		
+
 		local V1Hit = Norm(hitPos - Vertex1)
-		
+
 		if	Dot( V1V2, V1V3 ) < Dot( V1V2, V1Hit ) and
 			Dot( V1V3, V1V2 ) < Dot( V1V3, V1Hit ) and
 			Dot( V1V2, Norm(Vertex3 - Vertex2) ) > Dot( V1V2, Norm(hitPos - Vertex2) ) then
-			
+
 			return hitPos
-			
+
 		end
-		
+
 	end
-	
+
 	return false
-	
+
 end
 
 local boxNormals = {
@@ -162,8 +134,8 @@ local boxNormals = {
 	Vector(0,0,-1)
 }
 local function RayAABBoxIntersection( Start, Dir, Pos, Size )
-	
-	//Getting the sizes for the faces let us scale the box a lil.
+
+	-- Getting the sizes for the faces let us scale the box a lil.
 	local boxSizes = {
 		Vector(Size.z,Size.y,0),
 		Vector(Size.z,Size.x,0),
@@ -172,126 +144,126 @@ local function RayAABBoxIntersection( Start, Dir, Pos, Size )
 		Vector(Size.z,Size.x,0),
 		Vector(Size.x,Size.y,0)
 	}
-	
+
 	local closestDist
 	local closestHitPos
 	local closestNormal
-	
+
 	for i=1,6 do
-		
+
 		local normal = boxNormals[i]
 		local faceSize = boxSizes[i]
-		
+
 		if (Dot(normal, Dir) < 0) then
-			
+
 			local planePos = Pos + normal * (Size/2)
 			local HitPos = RayFaceIntersection( Start, Dir, planePos, normal, faceSize, 0 )
-			
+
 			if (HitPos) then
-				local dist = Distance(HitPos, Start) 
+				local dist = Distance(HitPos, Start)
 				if (!closestDist or dist < closestDist) then
 					closestDist = dist
 					closestHitPos = HitPos
 					closestNormal = normal
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	if (closestHitPos) then return closestHitPos, closestNormal end
-	
+
 	return false
-	
+
 end
 
 local function RayOBBoxIntersection( Start, Dir, Pos, Size, Ang )
-	
-	//To use an oriented-bounding-box we make the ray local (so we can use the AABB code)
+
+	-- To use an oriented-bounding-box we make the ray local (so we can use the AABB code)
 	local localRayStart = WorldToLocal( Start, Angle(0,0,0), Pos, Ang )
-	
-	//The direction need to be local to 0,0,0 though
+
+	-- The direction need to be local to 0,0,0 though
 	local localRayDir = WorldToLocal( Dir, Angle(0,0,0), Vector(0,0,0), Ang )
-	
-	//Use AABB code as that is easyer than calculating the normals of the faces and their angle aroudn that axis
+
+	-- Use AABB code as that is easyer than calculating the normals of the faces and their angle aroudn that axis
 	local localHitPos, localHitNormal = RayAABBoxIntersection( localRayStart, localRayDir, Vector(0,0,0), Size )
-	
-	//But we want the returned hitpos to be a world coord
+
+	-- But we want the returned hitpos to be a world coord
 	if (localHitPos) then
 		local hitPos = LocalToWorld( localHitPos, Angle(0,0,0), Pos, Ang )
 		local hitNormal = LocalToWorld( localHitNormal, Angle(0,0,0), Vector(0,0,0), Ang )
-		
+
 		return hitPos, hitNormal
 	end
-	
+
 	return false
-	
+
 end
 
 local function RayCircleIntersection( Start, Dir, Pos, Normal, Radius )
-	
+
 	local HitPos = RayPlaneIntersection( Start, Dir, Pos, Normal )
-	
+
 	if (HitPos) then
 		local Dist = Distance(Pos, HitPos)
-		
+
 		if (Dist < Radius) then return HitPos, Dist end
 	end
-	
+
 	return false
-	
+
 end
 
 local function RaySphereIntersection( Start, Dir, Pos, Radius )
-	
-	//New ray-sphere intersection code
+
+	-- New ray-sphere intersection code
 	--[
 	local A = 2 * Length(Dir)^2
 	local B = 2 * Dot(Dir,Start - Pos)
 	local C = Length(Pos)^2 + Length(Start)^2 - 2 * Dot(Pos,Start) - Radius^2
-	
+
 	local BAC4 = B^2-(2*A*C)
-	
+
 	if (BAC4 >= 0 and B < 0) then
-		//Enter sphere
+		-- Enter sphere
 		return Start + ((-sqrt(BAC4) - B) / A)*Dir
-		
-		//Exits sphere
-		//return Start + ((sqrt(BAC4) - B) / A)*Dir
+
+		-- Exits sphere
+		-- return Start + ((sqrt(BAC4) - B) / A)*Dir
 	end
 	--]]
-	
-	//Old ray-sphere intersection code (slower)
+
+	-- Old ray-sphere intersection code (slower)
 	--[[
 	local Normal = Dir * -1
 	local B = Normal:Dot(Pos-Start) / Normal:Dot(Dir)
-	
-	//It is a ray, not line, for a line segment, just add a distance chek.
+
+	-- It is a ray, not line, for a line segment, just add a distance chek.
 	if (B >= 0) then
-		
+
 		local HitPos = Start + Dir * B
-		
+
 		local Dist = Distance(Pos, HitPos)
-		
+
 		if (Dist < Radius) then
 			HitPos = HitPos - Dir * sqrt(Radius ^ 2 - Dist ^ 2)
-			
+
 			return HitPos
 		end
-		
+
 	end
 	--]]
-	
+
 	return false
-	
+
 end
 
 local function RayAAEllipsoidIntersection( Start, Dir, Pos, Size )
-	
+
 	local RayPos = Start - Pos
 	local RayDir = Norm(Dir)
-	
+
 	--This boosts my performance by only having to do ^2 once per variable, instead of 3.
 	local ElipsoidRadiusX2 = Size.x^2
 	local ElipsoidRadiusY2 = Size.y^2
@@ -314,74 +286,74 @@ local function RayAAEllipsoidIntersection( Start, Dir, Pos, Size )
 
 	if (D >= 0) then
 		D = sqrt(D)
-		
+
 		local Hit1 = (-B + D) / (2 * A)
 		local Hit2 = (-B - D) / (2 * A)
-		
+
 		if (Hit1 < Hit2) then
 			return Start + RayDir * Hit1
 		else
 			return Start + RayDir * Hit2
 		end
 	end
-	
+
 	return false
-	
+
 end
 
 local function RayOEllipsoidIntersection( Start, Dir, Pos, Size, Ang )
-	
-	//To use an oriented-bounding-box we make the ray local (so we can use the AABB code)
+
+	-- To use an oriented-bounding-box we make the ray local (so we can use the AABB code)
 	local localRayStart = WorldToLocal( Start, Angle(0,0,0), Pos, Ang )
-	
-	//The direction need to be local to 0,0,0 though
+
+	-- The direction need to be local to 0,0,0 though
 	local localRayDir = WorldToLocal( Dir, Angle(0,0,0), Vector(0,0,0), Ang )
-	
-	//Use AABB code as that is easyer than calculating the normals of the faces and their angle aroudn that axis
+
+	-- Use AABB code as that is easyer than calculating the normals of the faces and their angle aroudn that axis
 	local localHitPos = RayAAEllipsoidIntersection( localRayStart, localRayDir, Vector(0,0,0), Size )
-	
-	//But we want the returned hitpos to be a world coord
+
+	-- But we want the returned hitpos to be a world coord
 	if (localHitPos) then
 		local hitPos = LocalToWorld( localHitPos, Angle(0,0,0), Pos, Ang )
 
 		return hitPos
 	end
-	
+
 	return false
-	
+
 end
 
 
 local function ConeSphereIntersection( Start, Dir, Pos, Radius, Ang )
-	
+
 	local HitPos = RaySphereIntersection( Start, Dir, Pos, Radius )
-	
-	//If we hit with a normal trace we dont need to calculate for a cone
+
+	-- If we hit with a normal trace we dont need to calculate for a cone
 	if (HitPos) then return HitPos, 0 end
 	if (Ang == 0) then return false end
-	
-	//Normal of the plane is -Dir because that makes the face perfectly perpendicular to the trace, and facing towards the origin
+
+	-- Normal of the plane is -Dir because that makes the face perfectly perpendicular to the trace, and facing towards the origin
 	HitPos = RayPlaneIntersection( Start, Dir, Pos, Dir * -1 )
-	
+
 	if (!HitPos) then return false end
-	
-	//Calculate where on a circle would be closest to the plane hitpos
+
+	-- Calculate where on a circle would be closest to the plane hitpos
 	HitPos = Pos + Norm(HitPos-Pos) * Radius
-	
-	//Get angle between the vector we aim and vector to the circle "hitpos"
+
+	-- Get angle between the vector we aim and vector to the circle "hitpos"
 	VecAng = math.deg( math.acos( Dot( Norm(Dir), Norm(HitPos-Start) ) ) )
-	
+
 	if (VecAng <= Ang) then return HitPos, VecAng end
-	
+
 	return false
-	
+
 end
 
 
 
-/************************
+--[[***********************
 *****     * functions     *****
-*************************/
+************************]]
 
 
 local playerAmount = {}
@@ -412,23 +384,23 @@ local models = {
 }
 
 local function ShapeCreate( index, model, radius, rotation, pos, normal, size, ang, vertices, self )
-	
+
 	if (!table.HasValue( models, model )) then return "Invalid model." end
-	
+
 	if (model == "polygon") then return ShapeCreatePolygon( index, vertices, self ) end
-	
+
 	if (!shapes[self.player][self.entity][index]) then
 		playerAmount[self.player] = playerAmount[self.player]+1
 	end
-	
+
 	local shape = {}
-	
-	//Unmodifiable
+
+	-- Unmodifiable
 	shape.Index = index
 	shape.Entity = self.entity
 	shape.Owner = self.player
-	
-	//Modifiable
+
+	-- Modifiable
 	shape.Model = model
 	shape.Radius = radius
 	shape.Rotation = rotation
@@ -436,100 +408,100 @@ local function ShapeCreate( index, model, radius, rotation, pos, normal, size, a
 	shape.Normal = normal
 	shape.Size = size
 	shape.Ang = ang
-	
+
 	shape.Vertices = nil
-	
+
 	shapes[self.player][self.entity][index] = shape
-	
+
 	return ""
-	
+
 end
 
 local function ShapeCreatePolygon( index, vertices, self )
-	
+
 	if (!shapes[self.player][self.entity][index]) then
 		playerAmount[self.player] = playerAmount[self.player]+1
 	end
-	
+
 	local shape = {}
-	
-	//Unmodifiable
+
+	-- Unmodifiable
 	shape.Index = index
 	shape.Entity = self.entity
 	shape.Owner = self.player
-	
-	//Modifiable
+
+	-- Modifiable
 	shape.Model = "polygon"
 	shape.Vertices = vertices
 	shape.Pos = (vertices[1] + vertices[2] + vertices[3]) / 3
-	
+
 	shape.Radius = 0
 	shape.Rotation = 0
 	shape.Normal = Vector(0,0,0)
 	shape.Size = Vector(0,0,0)
 	shape.Ang = Angle(0,0,0)
-	
+
 	shapes[self.player][self.entity][index] = shape
-	
+
 	return ""
-	
+
 end
 
 local function ShapeModel( index, model, self )
-	
+
 	if (!table.HasValue( models, model )) then return "Invalid model." end
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	shape.Model = model
-	
+
 	return ""
-	
+
 end
 
 local function ShapeRadius( index, radius, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	shape.Radius = radius
-	
+
 	return ""
-	
+
 end
 
 local function ShapeRotation( index, rotation, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	shape.Rotation = rotation
-	
+
 	return ""
-	
+
 end
 
 local function ShapePos( index, pos, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	if (shape.Parent) then
 		shape.Pos = shape.Parent:WorldToLocal(pos)
 	else
 		shape.Pos = pos
 	end
-	
+
 	return ""
-	
+
 end
 
 local function ShapeVertices( index, vertices, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	if (shape.Parent) then
 		vertices[1] = shape.Parent:WorldToLocal(vertices[1])
 		vertices[2] = shape.Parent:WorldToLocal(vertices[2])
@@ -538,59 +510,59 @@ local function ShapeVertices( index, vertices, self )
 	else
 		shape.Vertices = vertices
 	end
-	
+
 	return ""
-	
+
 end
 
 local function ShapeAng( index, ang, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	if (shape.Parent) then
 		shape.Ang = shape.Parent:WorldToLocal(ang)
 	else
 		shape.Ang = ang
 	end
-	
+
 	return ""
-	
+
 end
 
 local function ShapeNormal( index, normal, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	if (shape.Parent) then
 		shape.Normal = WorldToLocal( normal, Angle(0,0,0), Vector(0,0,0), shape.Parent:GetAngles() )
 	else
 		shape.Normal = normal
 	end
-	
+
 	return ""
-	
+
 end
 
 local function ShapeSize( index, size, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	shape.Size = size
-	
+
 	return ""
-	
+
 end
 
 local function ShapeParent( index, parent, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	if (parent) then
-		
+
 		local pos, ang, normal, rotation, vertices
 		if (shape.Parent) then
 			pos, ang, normal, rotation, vertices = GetWorldData(shape)
@@ -598,12 +570,12 @@ local function ShapeParent( index, parent, self )
 			pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 			local vertices = shape.Vertices
 		end
-		
+
 		shape.Pos = parent:WorldToLocal(pos)
 		shape.Ang = parent:WorldToLocalAngles(ang)
 		shape.Normal = WorldToLocal( normal, Angle(0,0,0), Vector(0,0,0), parent:GetAngles() )
-		shape.Rotation = rotation //Work on
-		
+		shape.Rotation = rotation -- Work on
+
 		if vertices then
 			shape.Vertices[1] = parent:WorldToLocal(vertices[1])
 			shape.Vertices[2] = parent:WorldToLocal(vertices[2])
@@ -611,25 +583,25 @@ local function ShapeParent( index, parent, self )
 		else
 			shape.Vertices = nil
 		end
-		
+
 	end
-	
+
 	shape.Parent = parent
-	
+
 	return ""
-	
+
 end
 
 local function ShapeRemove( index, self )
-	
+
 	local shape = shapes[self.player][self.entity][index]
 	if (!shape) then return "Invalid index." end
-	
+
 	playerAmount[self.player] = playerAmount[self.player]-1
 	shapes[self.player][self.entity][index] = nil
-	
+
 	return ""
-	
+
 end
 
 local function ShapeClear( self )
@@ -641,33 +613,33 @@ end
 
 
 
-/***********************************
+--[[***********************************
 *****     Ts intersection functions     *****
-***********************************/
+***********************************]]
 
 local function GetWorldData(shape)
-	
+
 	local parent = shape.Parent
-	
+
 	local pos = parent:LocalToWorld(shape.Pos)
 	local ang = parent:LocalToWorldAngles(shape.Ang)
-	
+
 	local normal = LocalToWorld( shape.Normal, Angle(0,0,0), Vector(0,0,0), shape.Parent:GetAngles() )
-	local rotation = shape.Rotation //Work On
-	
+	local rotation = shape.Rotation -- Work On
+
 	local vertices = shape.Vertices
 	if vertices then
 		vertices[1] = parent:LocalToWorld(vertices[1])
 		vertices[2] = parent:LocalToWorld(vertices[2])
 		vertices[3] = parent:LocalToWorld(vertices[3])
 	end
-	
+
 	return pos, ang, normal, rotation, vertices
-	
+
 end
 
 local function FillTraceData( trace, shape )
-	
+
 	local pos, ang, normal, rotation, vertices
 	if (shape.Parent) then
 		pos, ang, normal, rotation, vertices = GetWorldData(shape)
@@ -675,7 +647,7 @@ local function FillTraceData( trace, shape )
 		pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 		vertices = shape.Vertices
 	end
-	
+
 	trace.Hit = 1
 	trace.Index = shape.Index
 	trace.Radius = shape.Radius
@@ -689,404 +661,404 @@ local function FillTraceData( trace, shape )
 	trace.Parent = shape.Parent
 	trace.HitEntity = shape.Entity
 	trace.HitOwner = shape.Owner
-	
+
 end
 
 
 local function TsRayPlaneIntersection( start, dir, self )
-	
+
 	local traces = {}
-	
+
 	for ply,plyGates in pairs(shapes) do
-		
+
 		for gate,gateShapes in pairs(plyGates) do
-			
+
 			local cont = false
-			
-			//If player is not same player who trace and e2's does not share with other players e2
+
+			-- If player is not same player who trace and e2's does not share with other players e2
 			if (ply ~= self.player and (sharing[ply][gate] ~= 2 or sharing[self.player][self.entity] ~= 2)) then cont = true end
-			
-			//If e2 is not same as e2 that trace and e2 does not share at all
+
+			-- If e2 is not same as e2 that trace and e2 does not share at all
 			if (gate ~= self.entity and (sharing[ply][gate] == 0 or sharing[self.player][self.entity] == 0)) then cont = true end
-			
+
 			if (!cont) then
 				for k,shape in pairs(gateShapes) do
-					
-					if (shape.Model == "plane") then 
-						
+
+					if (shape.Model == "plane") then
+
 						local pos, ang, normal, rotation
 						if (shape.Parent) then
 							pos, ang, normal, rotation = GetWorldData(shape)
 						else
 							pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 						end
-						
+
 						local hitPos = RayPlaneIntersection( start, dir, pos, normal )
-						
+
 						if (hitPos) then
 							local trace = {}
-							
+
 							FillTraceData( trace, shape )
-							
+
 							trace.HitAngle = 0
 							trace.StartPos = start
 							trace.HitPos = hitPos
-							
+
 							table.insert( traces, trace )
 						end
-						
+
 					end
-					
+
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return traces
-	
+
 end
 
 local function TsRayFaceIntersection( start, dir, self )
-	
+
 	local traces = {}
-	
+
 	for ply,plyGates in pairs(shapes) do
-		
+
 		for gate,gateShapes in pairs(plyGates) do
-			
+
 			local cont = false
-			
-			//If player is not same player who trace and e2's does not share with other players e2
+
+			-- If player is not same player who trace and e2's does not share with other players e2
 			if (ply ~= self.player and (sharing[ply][gate] ~= 2 or sharing[self.player][self.entity] ~= 2)) then cont = true end
-			
-			//If e2 is not same as e2 that trace and e2 does not share at all
+
+			-- If e2 is not same as e2 that trace and e2 does not share at all
 			if (gate ~= self.entity and (sharing[ply][gate] == 0 or sharing[self.player][self.entity] == 0)) then cont = true end
-			
+
 			if (!cont) then
 				for k,shape in pairs(gateShapes) do
-					
+
 					if (shape.Model == "face") then
-						
+
 						local pos, ang, normal, rotation
 						if (shape.Parent) then
 							pos, ang, normal, rotation = GetWorldData(shape)
 						else
 							pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 						end
-						
+
 						local hitPos = RayFaceIntersection( start, dir, pos, normal, shape.Size, rotation )
-						
+
 						if (hitPos) then
 							local trace = {}
-							
+
 							FillTraceData( trace, shape )
-							
+
 							trace.HitAngle = 0
 							trace.StartPos = start
 							trace.HitPos = hitPos
-							
+
 							table.insert( traces, trace )
 						end
-						
+
 					end
-					
+
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return traces
-	
+
 end
 
 local function TsRayPolygonIntersection( start, dir, self )
-	
+
 	local traces = {}
-	
+
 	for ply,plyGates in pairs(shapes) do
-		
+
 		for gate,gateShapes in pairs(plyGates) do
-			
+
 			local cont = false
-			
-			//If player is not same player who trace and e2's does not share with other players e2
+
+			-- If player is not same player who trace and e2's does not share with other players e2
 			if (ply ~= self.player and (sharing[ply][gate] ~= 2 or sharing[self.player][self.entity] ~= 2)) then cont = true end
-			
-			//If e2 is not same as e2 that trace and e2 does not share at all
+
+			-- If e2 is not same as e2 that trace and e2 does not share at all
 			if (gate ~= self.entity and (sharing[ply][gate] == 0 or sharing[self.player][self.entity] == 0)) then cont = true end
-			
+
 			if (!cont) then
 				for k,shape in pairs(gateShapes) do
-					
+
 					if (shape.Model == "polygon") then
-						
+
 						local pos, ang, normal, rotation, vertices
 						if (shape.Parent) then
 							pos, ang, normal, rotation, vertices = GetWorldData(shape)
 						else
 							pos, ang, normal, rotation, vertices = shape.Pos, shape.Ang, shape.Normal, shape.Rotation, shape.Vertices
 						end
-						
+
 						local hitPos = RayPolygonIntersection( start, dir, vertices )
-						
+
 						if (hitPos) then
 							local trace = {}
-							
+
 							FillTraceData( trace, shape )
-							
+
 							trace.HitAngle = 0
 							trace.StartPos = start
 							trace.HitPos = hitPos
-							
+
 							table.insert( traces, trace )
 						end
-						
+
 					end
-					
+
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return traces
-	
+
 end
 
 
 local function TsRayBoxIntersection( start, dir, self )
-	
+
 	local traces = {}
-	
+
 	for ply,plyGates in pairs(shapes) do
-		
+
 		for gate,gateShapes in pairs(plyGates) do
-			
+
 			local cont = false
-			
-			//If player is not same player who trace and e2's does not share with other players e2
+
+			-- If player is not same player who trace and e2's does not share with other players e2
 			if (ply ~= self.player and (sharing[ply][gate] ~= 2 or sharing[self.player][self.entity] ~= 2)) then cont = true end
-			
-			//If e2 is not same as e2 that trace and e2 does not share at all
+
+			-- If e2 is not same as e2 that trace and e2 does not share at all
 			if (gate ~= self.entity and (sharing[ply][gate] == 0 or sharing[self.player][self.entity] == 0)) then cont = true end
-			
+
 			if (!cont) then
 				for k,shape in pairs(gateShapes) do
-					
+
 					if (shape.Model == "box") then
-						
+
 						local pos, ang, normal, rotation
 						if (shape.Parent) then
 							pos, ang, normal, rotation = GetWorldData(shape)
 						else
 							pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 						end
-						
+
 						local hitPos, hitNormal = RayOBBoxIntersection( start, dir, pos, shape.Size, ang )
-						
+
 						if (hitPos) then
 							local trace = {}
-							
+
 							FillTraceData( trace, shape )
-							
+
 							trace.HitAngle = 0
 							trace.StartPos = start
 							trace.HitPos = hitPos
 							trace.HitNormal = hitNormal
-							
+
 							table.insert( traces, trace )
 						end
-						
+
 					end
-					
+
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return traces
-	
+
 end
 
 local function TsRayCircleIntersection( start, dir, self )
-	
+
 	local traces = {}
-	
+
 		for ply,plyGates in pairs(shapes) do
-		
+
 		for gate,gateShapes in pairs(plyGates) do
-			
+
 			local cont = false
-			
-			//If player is not same player who trace and e2's does not share with other players e2
+
+			-- If player is not same player who trace and e2's does not share with other players e2
 			if (ply ~= self.player and (sharing[ply][gate] ~= 2 or sharing[self.player][self.entity] ~= 2)) then cont = true end
-			
-			//If e2 is not same as e2 that trace and e2 does not share at all
+
+			-- If e2 is not same as e2 that trace and e2 does not share at all
 			if (gate ~= self.entity and (sharing[ply][gate] == 0 or sharing[self.player][self.entity] == 0)) then cont = true end
-			
+
 			if (!cont) then
 				for k,shape in pairs(gateShapes) do
-					
+
 					if (shape.Model == "circle") then
-						
+
 						local pos, ang, normal, rotation
 						if (shape.Parent) then
 							pos, ang, normal, rotation = GetWorldData(shape)
 						else
 							pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 						end
-						
+
 						local hitPos = RayCircleIntersection( start, dir, pos, normal, shape.Radius )
-						
+
 						if (hitPos) then
 							local trace = {}
-							
+
 							FillTraceData( trace, shape )
-							
+
 							trace.HitAngle = 0
 							trace.StartPos = start
 							trace.HitPos = hitPos
-							
+
 							table.insert( traces, trace )
 						end
-						
+
 					end
-					
+
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return traces
-	
+
 end
 
 local function TsRaySphereIntersection( start, dir, self )
-	
+
 	local traces = {}
-	
+
 	for ply,plyGates in pairs(shapes) do
-		
+
 		for gate,gateShapes in pairs(plyGates) do
-			
+
 			local cont = false
-			
-			//If player is not same player who trace and e2's does not share with other players e2
+
+			-- If player is not same player who trace and e2's does not share with other players e2
 			if (ply ~= self.player and (sharing[ply][gate] ~= 2 or sharing[self.player][self.entity] ~= 2)) then cont = true end
-			
-			//If e2 is not same as e2 that trace and e2 does not share at all
+
+			-- If e2 is not same as e2 that trace and e2 does not share at all
 			if (gate ~= self.entity and (sharing[ply][gate] == 0 or sharing[self.player][self.entity] == 0)) then cont = true end
-			
+
 			if (!cont) then
 				for k,shape in pairs(gateShapes) do
-					
+
 					if (shape.Model == "sphere") then
-						
+
 						local pos, ang, normal, rotation
 						if (shape.Parent) then
 							pos, ang, normal, rotation = GetWorldData(shape)
 						else
 							pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 						end
-						
+
 						local hitPos = RaySphereIntersection( start, dir, pos, shape.Radius )
-						
+
 						if (hitPos) then
 							local trace = {}
-							
+
 							FillTraceData( trace, shape )
-							
+
 							trace.HitAngle = 0
 							trace.StartPos = start
 							trace.HitPos = hitPos
 							trace.HitNormal = Norm(hitPos - pos)
-							
+
 							table.insert( traces, trace )
 						end
-						
+
 					end
-					
+
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return traces
-	
+
 end
 
 local function TsRayEllipsoidIntersection( start, dir, self )
-	
+
 	local traces = {}
-	
+
 	for ply, plyGates in pairs(shapes) do
-		
+
 		for gate, gateShapes in pairs(plyGates) do
-			
+
 			local cont = false
-			
-			//If player is not same player who trace and e2's does not share with other players e2
+
+			-- If player is not same player who trace and e2's does not share with other players e2
 			if (ply ~= self.player and (sharing[ply][gate] ~= 2 or sharing[self.player][self.entity] ~= 2)) then cont = true end
-			
-			//If e2 is not same as e2 that trace and e2 does not share at all
+
+			-- If e2 is not same as e2 that trace and e2 does not share at all
 			if (gate ~= self.entity and (sharing[ply][gate] == 0 or sharing[self.player][self.entity] == 0)) then cont = true end
-			
+
 			if (!cont) then
 				for k,shape in pairs(gateShapes) do
-					
+
 					if (shape.Model == "ellipsoid") then
-						
+
 						local pos, ang, normal, rotation
 						if (shape.Parent) then
 							pos, ang, normal, rotation = GetWorldData(shape)
 						else
 							pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 						end
-						
+
 						local hitPos = RayOEllipsoidIntersection( start, dir, pos, shape.Size, ang )
-						
+
 						if (hitPos) then
 							local trace = {}
-							
+
 							FillTraceData( trace, shape )
-							
+
 							trace.HitAngle = 0
 							trace.StartPos = start
 							trace.HitPos = hitPos
 							trace.HitNormal = Norm(hitPos - pos)
-							
+
 							table.insert( traces, trace )
 						end
-						
+
 					end
-					
+
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return traces
-	
+
 end
 
 
 local function TsRayIntersection( start, dir, self )
-	
+
 	local traces = {}
-	
+
 	local rayPlane = TsRayPlaneIntersection( start, dir, self )
 	local rayFace = TsRayFaceIntersection( start, dir, self )
 	local rayPolygon = TsRayPolygonIntersection( start, dir, self )
@@ -1094,7 +1066,7 @@ local function TsRayIntersection( start, dir, self )
 	local rayCircle = TsRayCircleIntersection( start, dir, self )
 	local raySphere = TsRaySphereIntersection( start, dir, self )
 	local rayEllipsoid = TsRayEllipsoidIntersection( start, dir, self )
-	
+
 	table.Add(traces,rayPlane)
 	table.Add(traces,rayFace)
 	table.Add(traces,rayPolygon)
@@ -1102,233 +1074,233 @@ local function TsRayIntersection( start, dir, self )
 	table.Add(traces,rayCircle)
 	table.Add(traces,raySphere)
 	table.Add(traces,rayEllipsoid)
-	
+
 	return traces
-	
+
 end
 
 
 local function TsConeSphereIntersection( start, dir, angle, self )
-	
+
 	local traces = {}
-	
+
 	for ply,plyGates in pairs(shapes) do
-		
+
 		for gate,gateShapes in pairs(plyGates) do
-			
+
 			local cont = false
-			
-			//If player is not same player who trace and e2's does not share with other players e2
+
+			-- If player is not same player who trace and e2's does not share with other players e2
 			if (ply ~= self.player and (sharing[ply][gate] ~= 2 or sharing[self.player][self.entity] ~= 2)) then cont = true end
-			
-			//If e2 is not same as e2 that trace and e2 does not share at all
+
+			-- If e2 is not same as e2 that trace and e2 does not share at all
 			if (gate ~= self.entity and (sharing[ply][gate] == 0 or sharing[self.player][self.entity] == 0)) then cont = true end
-			
+
 			if (!cont) then
 				for k,shape in pairs(gateShapes) do
-					
+
 					if (shape.Model == "sphere") then
-						
+
 						local pos, ang, normal, rotation
 						if (shape.Parent) then
 							pos, ang, normal, rotation = GetWorldData(shape)
 						else
 							pos, ang, normal, rotation = shape.Pos, shape.Ang, shape.Normal, shape.Rotation
 						end
-						
+
 						local hitPos, hitAngle = ConeSphereIntersection( start, dir, pos, shape.Radius, angle )
-						
+
 						if (hitPos) then
 							local trace = {}
-							
+
 							FillTraceData( trace, shape )
-							
+
 							trace.HitAngle = hitAngle
 							trace.StartPos = start
 							trace.HitPos = hitPos
 							trace.HitNormal = Norm(hitPos - pos)
-							
+
 							table.insert( traces, trace )
 						end
-						
+
 					end
-					
+
 				end
 			end
-			
+
 		end
-		
+
 	end
-	
+
 	return traces
-	
+
 end
 
 
 
-/******************************
+--[[******************************
 *****     Retrieval functions     *****
-******************************/
+******************************]]
 
 local function SortByDistance( traces, pos )
-	
+
 	table.sort(traces, function(a, b)
 		return Distance(pos, a.HitPos) < Distance(pos, b.HitPos)
 	end)
-	
+
 	return #traces
-	
+
 end
 
 local function Count( traces )
-	
+
 	return #traces
-	
+
 end
 
 
 local function GetHit( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Hit
 	end
-	
+
 	return 0
 end
 
 local function GetHitAngle( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].HitAngle
 	end
-	
+
 	return 0
 end
 
 local function GetHitIndex( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Index
 	end
-	
+
 	return 0
 end
 
 local function GetHitDistance( traces, index )
-	
+
 	if (traces[index]) then
 		local trace = traces[index]
-		
+
 		return Distance(trace.StartPos, trace.HitPos)
 	end
-	
+
 	return 0
 end
 
 local function GetHitRadius( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Radius
 	end
-	
+
 	return 0
 end
 
 local function GetHitRotation( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Rotation
 	end
-	
+
 	return 0
 end
 
 local function GetHitModel( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Model
 	end
-	
+
 	return ""
 end
 
 local function GetHitPos( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].HitPos
 	end
-	
+
 end
 
 local function GetHitOrigin( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Pos
 	end
-	
+
 end
 
 local function GetHitVertices( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Vertices
 	end
-	
+
 end
 
 local function GetHitAng( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Ang
 	end
-	
+
 end
 
 local function GetHitNormal( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].HitNormal
 	end
-	
+
 end
 
 local function GetHitSize( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Size
 	end
-	
+
 end
 
 local function GetHitParent( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].Parent
 	end
-	
+
 end
 
 local function GetHitEntity( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].HitEntity
 	end
-	
+
 end
 
 local function GetHitOwner( traces, index )
-	
+
 	if (traces[index]) then
 		return traces[index].HitOwner
 	end
-	
+
 end
 
 
 
-/************************
+--[[***********************
 *****     E2 Datatype     *****
-*************************/
+************************]]
 
 registerType("tracedata", "xtd", {},
 	nil,
@@ -1355,127 +1327,55 @@ end
 
 
 
-/************************************
+--[[***********************************
 *****     E2 Intersection functions     *****
-************************************/
+***********************************]]
 
 e2function vector rayPlaneIntersection( vector start, vector dir, vector pos, vector normal )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	normal = E2VecToLuaVec( normal )
-	
-	local hitPos = RayPlaneIntersection( start, dir, pos, normal )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RayPlaneIntersection( start, dir, pos, normal )
 end
 
 e2function vector rayFaceIntersection( vector start, vector dir, vector pos, vector normal, vector size, number ang )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	normal = E2VecToLuaVec( normal )
-	size = E2VecToLuaVec( size )
-	
-	local hitPos = RayFaceIntersection( start, dir, pos, normal, size, ang )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RayFaceIntersection( start, dir, pos, normal, size, ang )
 end
 
 e2function vector rayPolygonIntersection( vector start, vector dir, vector vertex1, vector vertex2, vector vertex3 )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	vertex1 = E2VecToLuaVec( vertex1 )
-	vertex2 = E2VecToLuaVec( vertex2 )
-	vertex3 = E2VecToLuaVec( vertex3 )
-	
-	local hitPos = RayPolygonIntersection( start, dir, {vertex1, vertex2, vertex3} )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RayPolygonIntersection( start, dir, {vertex1, vertex2, vertex3} )
 end
 
 e2function vector rayAABBoxIntersection( vector start, vector dir, vector pos, vector size )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	size = E2VecToLuaVec( size )
-	
-	local hitPos = RayAABBoxIntersection( start, dir, pos, size )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RayAABBoxIntersection( start, dir, pos, size )
 end
 
 e2function vector rayOBBoxIntersection( vector start, vector dir, vector pos, vector size, angle ang )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	size = E2VecToLuaVec( size )
-	ang = E2AngToLuaAng( ang )
-	
-	local hitPos = RayOBBoxIntersection( start, dir, pos, size, ang )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RayOBBoxIntersection( start, dir, pos, size, ang )
 end
 
 e2function vector rayCircleIntersection( vector start, vector dir, vector pos, vector normal, number radius )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	normal = E2VecToLuaVec( normal )
-	
-	local hitPos = RayCircleIntersection( start, dir, pos, normal, radius )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RayCircleIntersection( start, dir, pos, normal, radius )
 end
 
 e2function vector raySphereIntersection( vector start, vector dir, vector pos, number radius )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	
-	local hitPos = RaySphereIntersection( start, dir, pos, radius )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RaySphereIntersection( start, dir, pos, radius )
 end
 
 e2function vector rayAAEllipsoidIntersection( vector start, vector dir, vector pos, vector size )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	size = E2VecToLuaVec( size )
-	
-	local hitPos = RayAAEllipsoidIntersection( start, dir, pos, size )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RayAAEllipsoidIntersection( start, dir, pos, size )
 end
 
 e2function vector rayOEllipsoidIntersection( vector start, vector dir, vector pos, vector size, angle ang )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	size = E2VecToLuaVec( size )
-	ang = E2AngToLuaAng( ang )
-	
-	local hitPos = RayOEllipsoidIntersection( start, dir, pos, size, ang )
-	
-	return LuaVecToE2Vec( hitPos )
+	return RayOEllipsoidIntersection( start, dir, pos, size, ang )
 end
 
 e2function vector coneSphereIntersection( vector start, vector dir, vector pos, number radius, number ang )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	pos = E2VecToLuaVec( pos )
-	
-	local hitPos = ConeSphereIntersection( start, dir, pos, radius, ang )
-	
-	return LuaVecToE2Vec( hitPos )
+	return ConeSphereIntersection( start, dir, pos, radius, ang )
 end
 
 
 
-/**************************
+--[[*************************
 *****     E2 * functions     *****
-**************************/
+*************************]]
 
 e2function number tsShapeCanCreate( )
 	return GetConVarNumber("wire_shapes_max") - playerAmount[self.player]
@@ -1487,32 +1387,17 @@ end
 
 e2function string tsShapeCreate( number index, string model, number radius, rotation, vector pos, vector normal, vector size, angle ang, vector vertex1, vector vertex2, vector vertex3 )
 	if (!ShapeCanCreate( self.player )) then return "Limit reached" end
-	
-	pos = E2VecToLuaVec( pos )
-	normal = E2VecToLuaVec( normal )
-	size = E2VecToLuaVec( size )
-	ang = E2AngToLuaAng( ang )
-	
-	vertex1 = E2VecToLuaVec( vertex1 )
-	vertex2 = E2VecToLuaVec( vertex2 )
-	vertex3 = E2VecToLuaVec( vertex3 )
-	
 	return ShapeCreate( index, model, radius, rotation, pos, normal, size, ang, vertices, self )
 end
 
 e2function string tsShapeCreate( number index )
 	if (!ShapeCanCreate( self.player )) then return "Limit reached" end
-	
 	return ShapeCreate( index, "", 0, 0, Vector(0,0,0), Vector(0,0,0), Vector(0,0,0), Angle(0,0,0), {}, self )
 end
 
 e2function string tsShapePolygon( number index, vector vertex1, vector vertex2, vector vertex3 )
 	if (!ShapeCanCreate( self.player )) then return "Limit reached" end
-	
-	vertex1 = E2VecToLuaVec( vertex1 )
-	vertex2 = E2VecToLuaVec( vertex2 )
-	vertex3 = E2VecToLuaVec( vertex3 )
-	
+
 	return ShapeCreatePolygon( index, {vertex1, vertex2, vertex3}, self )
 end
 
@@ -1529,34 +1414,22 @@ e2function string tsShapeRotation( number index, number rotation )
 end
 
 e2function string tsShapePos( number index, vector pos )
-	pos = E2VecToLuaVec( pos )
-	
 	return ShapePos( index, pos, self )
 end
 
 e2function string tsShapeVertices( number index, vector vertex1, vector vertex2, vector vertex3 )
-	vertex1 = E2VecToLuaVec( vertex1 )
-	vertex2 = E2VecToLuaVec( vertex2 )
-	vertex3 = E2VecToLuaVec( vertex3 )
-	
 	return ShapeVertices( index, {vertex1, vertex2, vertex3}, self )
 end
 
 e2function string tsShapeAng( number index, angle ang )
-	ang = E2AngToLuaAng( ang )
-	
 	return ShapeAng( index, ang, self )
 end
 
 e2function string tsShapeNormal( number index, vector normal )
-	normal = E2VecToLuaVec( normal )
-	
 	return ShapeNormal( index, normal, self )
 end
 
 e2function string tsShapeSize( number index, vector size )
-	size = E2VecToLuaVec( size )
-	
 	return ShapeSize( index, size, self )
 end
 
@@ -1574,118 +1447,71 @@ end
 
 
 
-/**************************************
+--[[*************************************
 *****     E2 ts intersection functions     *****
-**************************************/
+*************************************]]
 
 e2function tracedata tsRayPlaneIntersection( vector start, vector dir )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces = TsRayPlaneIntersection( start, dir, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 e2function tracedata tsRayFaceIntersection( vector start, vector dir )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces = TsRayFaceIntersection( start, dir, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 e2function tracedata tsRayPolygonIntersection( vector start, vector dir )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces = TsRayPolygonIntersection( start, dir, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 e2function tracedata tsRayBoxIntersection( vector start, vector dir )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces =  TsRayBoxIntersection( start, dir, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 e2function tracedata tsRayCircleIntersection( vector start, vector dir )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces =  TsRayCircleIntersection( start, dir, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 e2function tracedata tsRaySphereIntersection( vector start, vector dir )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces =  TsRaySphereIntersection( start, dir, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 e2function tracedata tsRayEllipsoidIntersection( vector start, vector dir )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces =  TsRayEllipsoidIntersection( start, dir, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 e2function tracedata tsRayIntersection( vector start, vector dir )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces =  TsRayIntersection( start, dir, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 e2function tracedata tsConeSphereIntersection( vector start, vector dir, number angle )
-	start = E2VecToLuaVec( start )
-	dir = E2VecToLuaVec( dir )
-	
 	local traces =  TsConeSphereIntersection( start, dir, angle, self )
-	
 	SortByDistance( traces, start )
-	
 	return traces
 end
 
 
 
-/*********************************
+--[[********************************
 *****     E2 Retrieval functions     *****
-*********************************/
+********************************]]
 
 e2function number tracedata:sortByDistance( vector pos )
-	pos = E2VecToLuaVec( pos )
-	
 	return SortByDistance( this, pos )
 end
 
@@ -1752,25 +1578,25 @@ end
 
 e2function vector tracedata:hitPos( )
 	local hitPos = GetHitPos( this, 1 )
-	
+
 	return LuaVecToE2Vec(hitPos)
 end
 
 e2function vector tracedata:hitPos( number index )
 	local hitPos = GetHitPos( this, index )
-	
+
 	return LuaVecToE2Vec(hitPos)
 end
 
 e2function vector tracedata:pos( )
 	local pos = GetHitOrigin( this, 1 )
-	
+
 	return LuaVecToE2Vec(pos)
 end
 
 e2function vector tracedata:pos( number index )
 	local pos = GetHitOrigin( this, index )
-	
+
 	return LuaVecToE2Vec(pos)
 end
 
@@ -1783,39 +1609,27 @@ e2function vector tracedata:vertices( number index )
 end
 
 e2function angle tracedata:ang( )
-	local ang = GetHitAng( this, 1 )
-	
-	return LuaAngToE2Ang(ang)
+	return GetHitAng( this, 1 )
 end
 
 e2function angle tracedata:ang( number index )
-	local ang = GetHitAng( this, index )
-	
-	return LuaAngToE2Ang(ang)
+	return GetHitAng( this, index )
 end
 
 e2function vector tracedata:hitNormal( )
-	local hitNormal = GetHitNormal( this, 1 )
-	
-	return LuaVecToE2Vec(hitNormal)
+	return GetHitNormal( this, 1 )
 end
 
 e2function vector tracedata:hitNormal( number index )
-	local hitNormal = GetHitNormal( this, index )
-	
-	return LuaVecToE2Vec(hitNormal)
+	return GetHitNormal( this, index )
 end
 
 e2function vector tracedata:size( )
-	local size = GetHitSize( this, 1 )
-	
-	return LuaVecToE2Vec(size)
+	return GetHitSize( this, 1 )
 end
 
 e2function vector tracedata:size( number index )
-	local size = GetHitSize( this, index )
-	
-	return LuaVecToE2Vec(size)
+	return GetHitSize( this, index )
 end
 
 e2function entity tracedata:parent( )
@@ -1844,11 +1658,11 @@ end
 
 
 
-/*******************
+--[[******************
 *****     Hooks     *****
-*******************/
+******************]]
 
-//When an e2 is spawned
+-- When an e2 is spawned
 registerCallback("construct",function(self)
 	if (!sharing[self.player]) then
 		shapes[self.player] = {}
@@ -1859,18 +1673,18 @@ registerCallback("construct",function(self)
 	sharing[self.player][self.entity] = 0
 end)
 
-//When an e2 is removed
+-- When an e2 is removed
 registerCallback("destruct",function(self)
 	if sharing[self.player] and sharing[self.player][self.entity] then
 		ShapeClear( self )
-		
+
 		shapes[self.player][self.entity] = nil
 		sharing[self.player][self.entity] = nil
 	end
 end)
 
 
-//When player leaves, remove his shapes.
+-- When player leaves, remove his shapes.
 hook.Add("PlayerDisconnected","playerdisconnected",function(ply)
 	if (ply:IsValid() and ply:IsPlayer()) then
 		shapes[ply] = nil


### PR DESCRIPTION
**DO NOT MERGE THIS UNTIL https://github.com/wiremod/wire/pull/2399 IS MERGED.**

This PR converts functions that return a table with three numbers to proper Vector/Angle userdata, since that is what vector and angle types will now use in E2 for efficiency.

I'm sweeping through found instances of this on github and making these PRs to make sure the amount of extensions broken by this is minimal.