### PR TITLE
Make entity registration with undo and cleanup libraries consistent

### DIFF
--- a/lua/entities/wired_door/init.lua
+++ b/lua/entities/wired_door/init.lua
@@ -201,6 +201,7 @@ function ENT:makedoor(ply,trace,ang,model,open,close,autoclose,closetime,class,h
 		entit:Fire("addoutput","OnFullyClosed " .. xuuid .. ",xtfclose",0)
 	end
 
+	ply:AddCleanup( "doors", entit )
 	self.xent = entit
 	self.xclass = tostring(class)
 end

--- a/lua/weapons/gmod_tool/stools/wire_adv_hud_indicator_2.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv_hud_indicator_2.lua
@@ -3,6 +3,8 @@ TOOL.Name			= "Adv. Hud Indicator 2"
 TOOL.Command		= nil
 TOOL.ConfigName		= ""
 
+cleanup.Register( "wire_adv_hud_indicators" )
+
 if ( CLIENT ) then
     language.Add( "Tool_wire_adv_hud_indicator_2_name", "Adv. HUD Indicator 2 ! (Wire)" )
     language.Add( "Tool_wire_adv_hud_indicator_2_desc", "Spawns an Adv. HUD Indicator 2 for use with the wire system." )
@@ -48,6 +50,8 @@ function TOOL:LeftClick( trace )
 		undo.AddEntity( const )
 		undo.SetPlayer( player )
 	undo.Finish()
+
+	ply:AddCleanup( "wire_adv_hud_indicators", ent )
 
 	//-- Now that we have an entity, invoke its owner to send us code!
 	player:SendLua("HUD2_uploadCode(" .. ent:EntIndex() .. ")")

--- a/lua/weapons/gmod_tool/stools/wire_adv_hud_indicator_2.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv_hud_indicator_2.lua
@@ -51,7 +51,7 @@ function TOOL:LeftClick( trace )
 		undo.SetPlayer( player )
 	undo.Finish()
 
-	ply:AddCleanup( "wire_adv_hud_indicators", ent )
+	player:AddCleanup( "wire_adv_hud_indicators", ent )
 
 	//-- Now that we have an entity, invoke its owner to send us code!
 	player:SendLua("HUD2_uploadCode(" .. ent:EntIndex() .. ")")

--- a/lua/weapons/gmod_tool/stools/wire_door.lua
+++ b/lua/weapons/gmod_tool/stools/wire_door.lua
@@ -11,7 +11,7 @@ TOOL.ClientConVar[ "close" ] = "2"
 TOOL.ClientConVar[ "autoclose" ] = "0"
 TOOL.ClientConVar[ "closetime" ] = "5"
 TOOL.ClientConVar[ "hardware" ] = "1"
-cleanup.Register( "door" )
+cleanup.Register( "doors" )
 
 TOOL.Category		= "Wire Extras/Other"		// Name of the category
 TOOL.Name			= "#Door"		// Name to display
@@ -136,7 +136,7 @@ function TOOL.BuildCPanel( CPanel )
 	params.Options[ "SmallCombineDoor" ] = { wire_door_class = "prop_dynamic",wire_door_model = "models/combine_gate_citizen.mdl" }
 	params.Options[ "Door1" ] = { wire_door_hardware = "1",wire_door_class = "prop_door_rotating",wire_door_model = "models/props_c17/door01_left.mdl" }
 	params.Options[ "Door2" ] = { wire_door_hardware = "2",wire_door_class = "prop_door_rotating",wire_door_model = "models/props_c17/door01_left.mdl" }
-	params.Options[ "KlabBlastDoor(by †Omen†)" ] = { wire_door_class = "prop_dynamic",wire_door_model = "models/props_doors/doorKLab01.mdl" }
+	params.Options[ "KlabBlastDoor(by â€ Omenâ€ )" ] = { wire_door_class = "prop_dynamic",wire_door_model = "models/props_doors/doorKLab01.mdl" }
 
 	CPanel:AddControl( "ListBox", params )
 	CPanel:AddControl( "Slider",  { Label	= "#AutoClose Delay",

--- a/lua/weapons/gmod_tool/stools/wire_pid.lua
+++ b/lua/weapons/gmod_tool/stools/wire_pid.lua
@@ -14,6 +14,8 @@ TOOL.ClientConVar[ "limit" ] = "1000"
 
 TOOL.Model = "models/jaanus/wiretool/wiretool_siren.mdl"
 
+cleanup.Register( "wire_pids" )
+
 /* If we're running on the client, setup the description strings */
 if ( CLIENT ) then
     language.Add( "Tool.wire_pid.name", "PID Tool (Wire)" )
@@ -68,6 +70,8 @@ function TOOL:LeftClick( trace )
 		end
 		undo.SetPlayer(ply)
 	undo.Finish()
+
+	ply:AddCleanup( "wire_pids", ent )
 	return true
 end
 

--- a/lua/weapons/gmod_tool/stools/wnpc.lua
+++ b/lua/weapons/gmod_tool/stools/wnpc.lua
@@ -3,6 +3,7 @@ TOOL.Name			= "Wired Npc Controller"
 TOOL.Command		= nil
 TOOL.ConfigName		= ""
 TOOL.Tab			= "Wire"
+cleanup.Register( "wire_npc_controllers" )
 
 if CLIENT then
     language.Add( "Tool.wnpc.name", "Wired Npc Controller" )
@@ -26,6 +27,8 @@ function TOOL:LeftClick( trace )
 			undo.SetPlayer( ply )
 		undo.Finish()
 		self:SetStage(1)
+
+		ply:AddCleanup( "wire_npc_controllers", cont )
 	end	
 end
 
@@ -40,6 +43,8 @@ function TOOL:RightClick( trace )
 			undo.SetPlayer( ply )
 		undo.Finish()
 		self:SetStage(0)
+
+		ply:AddCleanup( "wire_npc_controllers", npcc )
 	end
 end
 


### PR DESCRIPTION
Currently, some CPPI based prop protection/permission systems struggle to register certain components from wire extras. I've combed through and added cleanup registries to those components missing them, allowing them to be picked up by more CPPI based systems.

The following components were made more consistent:
- Wire NPC Controller (and the NPC that it spawns)
- Wire PIDs
- Wire Door, which called the incorrect cleanup registry name (And the door that it spawns)
- Wire Adv. Hud Indicator 2