### PR TITLE
Workshop prep

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -11,9 +11,16 @@
 		"*.xcf",
 		".git*",
 		"*.md",
-		".travis.yml",
+		".glualint.json",
+		".github",
 		"git-hooks-pre-commit",
+		"gitrid.sh",
 		"LICENSE",
-		"wire_extras_icon.*"
+		"wire_extras_logo.*",
+
+		"cfg/*",
+		"beta/*",
+		"doc/*",
+		"data/*"
 	]
 }


### PR DESCRIPTION
This just modifies the addon.json so more stuff is explicitly ignored.

`gmod-upload` would already handle this for you, but nicer to update it.

Also plan to add the deploy workflow here once the addon exists