### PR TITLE
Fix one too many parenthesis in dynamic memory

### DIFF
--- a/lua/entities/gmod_wire_dynamicmemory/init.lua
+++ b/lua/entities/gmod_wire_dynamicmemory/init.lua
@@ -29,7 +29,7 @@ function ENT:Initialize()
 end
 
 function ENT:Setup( size )
-	local size = math.Clamp(math.floor( size or self.Size )), 1, 2097152)
+	local size = math.Clamp(math.floor( size or self.Size ), 1, 2097152)
 	local overheap = size - self.Size
 	
 	if ( overheap < 0 ) then


### PR DESCRIPTION
`addons/wireextras/lua/entities/gmod_wire_dynamicmemory/init.lua:32: unexpected symbol near ')'`