### PR TITLE
Fix notifications spam

### DIFF
--- a/lua/weapons/gmod_tool/stools/selfchanger.lua
+++ b/lua/weapons/gmod_tool/stools/selfchanger.lua
@@ -65,7 +65,7 @@ function TOOL:sendSetVal(ent, var, val)
 		net.WriteString(var)
 		net.WriteString(val)
 		net.WriteBool(bnv)
-	net.Broadcast()
+	net.Send(self:GetOwner())
 end
 
 function TOOL:LeftClick( trace )


### PR DESCRIPTION
Notifications are sent to all players on the server instead of the owner. This can cause the entire screen to be clogged with the same type of notifications

Example:
![image](https://github.com/user-attachments/assets/71f2c412-bf30-4f68-afd1-51a513135d30)