### PR TITLE
Fix a bunch of bugs in "Set Draw Params" tool

### DIFF
--- a/lua/autorun/client/lib-gui-panel-client.lua
+++ b/lua/autorun/client/lib-gui-panel-client.lua
@@ -134,9 +134,9 @@ end
 
 --calculate draw coefficients and offsets
 function gpCalcDrawCoefs(ent)
-	ent.XdrawCoef = ent.w or 1 / ent.drawParams and ent.drawParams.screenWidth or 1
+	ent.XdrawCoef = (ent.w or 1) / (ent.drawParams and ent.drawParams.screenWidth or 1)
 	ent.XdrawOffs = ent.x or 1
-	ent.YdrawCoef = ent.h or 1 / ent.drawParams and ent.drawParams.screenHeight or 1
+	ent.YdrawCoef = (ent.h or 1) / (ent.drawParams and ent.drawParams.screenHeight or 1)
 	ent.YdrawOffs = ent.y or 1
 end
 

--- a/lua/autorun/client/lib-gui-panel-client.lua
+++ b/lua/autorun/client/lib-gui-panel-client.lua
@@ -134,11 +134,10 @@ end
 
 --calculate draw coefficients and offsets
 function gpCalcDrawCoefs(ent)
-	ent.XdrawCoef = ent.w / ent.drawParams.screenWidth
-	ent.XdrawOffs = ent.x
-	ent.YdrawCoef = ent.h / ent.drawParams.screenHeight
-	ent.YdrawOffs = ent.y
-	--Msg("calc done\n")
+	ent.XdrawCoef = ent.w or 1 / ent.drawParams and ent.drawParams.screenWidth or 1
+	ent.XdrawOffs = ent.x or 1
+	ent.YdrawCoef = ent.h or 1 / ent.drawParams and ent.drawParams.screenHeight or 1
+	ent.YdrawOffs = ent.y or 1
 end
 
 --Make fonts for panel

--- a/lua/weapons/gmod_tool/stools/drawchanger.lua
+++ b/lua/weapons/gmod_tool/stools/drawchanger.lua
@@ -66,11 +66,8 @@ function TOOL:LeftClick( trace )
 	return true
 end
 
-function TOOL:RightClick(trace)
-	if not IsValid(trace.Entity) or trace.Entity:IsPlayer() then return false end
-	if CLIENT then return true end
-
-	return true
+function TOOL:RightClick( trace )
+	return false
 end
 
 function TOOL:Think()

--- a/lua/weapons/gmod_tool/stools/drawchanger.lua
+++ b/lua/weapons/gmod_tool/stools/drawchanger.lua
@@ -9,7 +9,6 @@ TOOL.ClientConVar["draww"] = ""
 TOOL.ClientConVar["drawh"] = ""
 TOOL.ClientConVar["drawres"] = ""
 
-
 if CLIENT then
     language.Add( "Tool_drawchanger_name", "Developer Tool" )
     language.Add( "Tool_drawchanger_desc", "change draw params" )
@@ -22,22 +21,24 @@ if CLIENT then
 	language.Add("Tool_drawchanger_drawh", "H:")
 	language.Add("Tool_drawchanger_drawres", "Res:")
 
-	function umGetNewSet()
+	net.Receive("umsgDrawChangerCfg", function()
 		local ent = net.ReadEntity()
+		if not IsValid(ent) then return end
+
+		ent.drawParams = ent.drawParams or {}
 		ent.drawParams.x = net.ReadFloat()
 		ent.drawParams.y = net.ReadFloat()
 		ent.drawParams.w = net.ReadFloat()
 		ent.drawParams.h = net.ReadFloat()
 		ent.drawParams.Res = net.ReadFloat()
+
 		gpCalcDrawCoefs(ent)
-	end
-	net.Receive("umsgDrawChangerCfg", umGetNewSet) 
+	end) 
 end
 
 if SERVER then
 	util.AddNetworkString("umsgDrawChangerCfg")
 	function TOOL:sendSetVal(ent, x, y, w, h, res)
-		Msg ("um send function\n")
 		net.Start("umsgDrawChangerCfg")
 			net.WriteEntity(ent)
 			net.WriteFloat(x)
@@ -50,22 +51,23 @@ if SERVER then
 end
 
 function TOOL:LeftClick( trace )
-	if trace.Entity && trace.Entity:IsPlayer() then return false end
+	if not IsValid(trace.Entity) then return false end
+	if trace.Entity:IsPlayer() then return false end
 	if CLIENT then return true end
 
-	local x = tonumber(self:GetClientInfo("drawx"))
-	local y = self:GetClientInfo("drawy")
-	local w = self:GetClientInfo("draww")
-	local h = self:GetClientInfo("drawh")
-	local res = self:GetClientInfo("drawres")
+	local x = self:GetClientNumber("drawx", 0)
+	local y = self:GetClientNumber("drawy", 0)
+	local w = self:GetClientNumber("draww", 0)
+	local h = self:GetClientNumber("drawh", 0)
+	local res = self:GetClientNumber("drawres", 0)
 	
 	self:sendSetVal(trace.Entity, x, y, w, h, res)
 	
 	return true
 end
 
-function TOOL:RightClick( trace )
-	if trace.Entity && trace.Entity:IsPlayer() then return false end
+function TOOL:RightClick(trace)
+	if not IsValid(trace.Entity) or trace.Entity:IsPlayer() then return false end
 	if CLIENT then return true end
 
 	return true


### PR DESCRIPTION
Fixes:
```
[wire-extras-master] addons/wire-extras-master/lua/weapons/gmod_tool/stools/drawchanger.lua:27: attempt to index field 'drawParams' (a nil value)
1. func - addons/wire-extras-master/lua/weapons/gmod_tool/stools/drawchanger.lua:27
 2. unknown - lua/includes/extensions/net.lua:38
```
```
[wire-extras-master] addons/wire-extras-master/lua/weapons/gmod_tool/stools/drawchanger.lua:44: bad argument #1 to 'WriteFloat' (number expected, got string)
1. WriteFloat - [C]:-1
 2. sendSetVal - addons/wire-extras-master/lua/weapons/gmod_tool/stools/drawchanger.lua:44
  3. LeftClick - addons/wire-extras-master/lua/weapons/gmod_tool/stools/drawchanger.lua:62
   4. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:234
```
```
[wire-extras-master] addons/wire-extras-master/lua/autorun/client/lib-gui-panel-client.lua:137: attempt to perform arithmetic on field 'w' (a nil value)
    1. gpCalcDrawCoefs - addons/wire-extras-master/lua/autorun/client/lib-gui-panel-client.lua:137
        2. func - addons/wire-extras-master/lua/weapons/gmod_tool/stools/drawchanger.lua:35
            3. unknown - lua/includes/extensions/net.lua:38
```