### PR TITLE
Fix NULL error

### DIFF
--- a/lua/entities/wired_door/init.lua
+++ b/lua/entities/wired_door/init.lua
@@ -43,7 +43,9 @@ function ENT:Initialize()
 end
 
 function ENT:OnRemove()
-	self.xent:Remove()
+	if IsValid(self.xent) then
+		self.xent:Remove()
+	end
 end
 
 function ENT:TriggerInput(iname, value)


### PR DESCRIPTION
Fixes:
```
[wire-extras-master] addons/wire-extras-master/lua/entities/wired_door/init.lua:46: Tried to use a NULL entity!
```